### PR TITLE
Update reinforcement window and inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,15 +225,14 @@ Esta organización modular facilita la comunicación y coordinación dentro del 
 
 Consulta el archivo [DESARROLLO.md](DESARROLLO.md) para pautas sobre configuración del entorno y aportes al código.
 
-## Vista 3D básica
+## Desarrollo de Refuerzo
 
-Se añadió un botón **Vista 3D** en la ventana de diseño que abre una
-representación simple de la viga. Esta ventana muestra una sección 2D y
-una vista tridimensional generada con Matplotlib. La longitud de la viga
-corresponde al valor ingresado en el campo **L (m)** de la primera
-ventana. Es una funcionalidad experimental que sirve como paso previo a
-la integración más completa descrita en
-[DESARROLLO_3D.md](DESARROLLO_3D.md).
+Se añadió un botón **Desarrollo de Refuerzo** en la ventana de diseño que abre
+una representación simple de la viga. Esta ventana muestra una sección 2D y una
+vista tridimensional generada con Matplotlib. La longitud de la viga se ingresa
+en esta tercera ventana mediante el campo **L (m)**. Es una funcionalidad
+experimental que sirve como paso previo a la integración más completa descrita
+en [DESARROLLO_3D.md](DESARROLLO_3D.md).
 
 ## Licencia
 

--- a/src/design_window.py
+++ b/src/design_window.py
@@ -47,12 +47,11 @@ DIAM_CM = {
 class DesignWindow(QMainWindow):
     """Ventana para la etapa de diseño de acero (solo interfaz gráfica)."""
 
-    def __init__(self, mn_corr, mp_corr, length=1.0):
+    def __init__(self, mn_corr, mp_corr):
         """Create the design window using corrected moments."""
         super().__init__()
         self.mn_corr = mn_corr
         self.mp_corr = mp_corr
-        self.length = length
         self.setWindowTitle("Parte 2 – Diseño de Acero")
         self._build_ui()
         self.resize(700, 900)
@@ -164,20 +163,12 @@ class DesignWindow(QMainWindow):
         self.edits["d (cm)"].setText(f"{d:.2f}")
         return d
 
-    def _on_length_changed(self):
-        """Update stored length when the user edits the L field."""
-        try:
-            self.length = float(self.edits["L (m)"].text())
-        except ValueError:
-            self.length = 1.0
-
     def _build_ui(self):
         central = QWidget()
         self.setCentralWidget(central)
         layout = QGridLayout(central)
 
         labels = [
-            ("L (m)", str(self.length)),
             ("b (cm)", "30"),
             ("h (cm)", "50"),
             ("r (cm)", "4"),
@@ -197,8 +188,6 @@ class DesignWindow(QMainWindow):
                 ed.setReadOnly(True)
             layout.addWidget(ed, row, 1)
             self.edits[text] = ed
-            if text == "L (m)":
-                ed.editingFinished.connect(self._on_length_changed)
 
         # Combos para diámetro de estribo y de varilla
         estribo_opts = ["8mm", "3/8\"", "1/2\""]
@@ -232,9 +221,9 @@ class DesignWindow(QMainWindow):
 
             header = QGridLayout()
             header.addWidget(QLabel("cant."), 0, 0, alignment=Qt.AlignCenter)
-            header.addWidget(QLabel("\u00f8''"), 0, 1, alignment=Qt.AlignCenter)
+            header.addWidget(QLabel("\u00f8 varill"), 0, 1, alignment=Qt.AlignCenter)
             header.addWidget(QLabel("n\u00b0 capas"), 0, 2, alignment=Qt.AlignCenter)
-            header.addWidget(QLabel("capas"), 0, 3, alignment=Qt.AlignCenter)
+            header.addWidget(QLabel("capas"), 0, 3, 1, 2, alignment=Qt.AlignCenter)
             cell.addLayout(header)
 
             rows_layout = QVBoxLayout()
@@ -275,7 +264,7 @@ class DesignWindow(QMainWindow):
 
         self.btn_capture = QPushButton("Capturar Diseño")
         self.btn_memoria = QPushButton("Memoria de Cálculo")
-        self.btn_view3d = QPushButton("Vista 3D")
+        self.btn_view3d = QPushButton("Desarrollo de Refuerzo")
         self.btn_salir = QPushButton("Salir")
 
         self.btn_capture.clicked.connect(self._capture_design)
@@ -315,8 +304,8 @@ class DesignWindow(QMainWindow):
         q = QComboBox(); q.addItems(qty_opts); q.setCurrentText("2")
         d = QComboBox(); d.addItems(dia_opts); d.setCurrentText('1/2"')
         c = QComboBox(); c.addItems(["1", "2", "3", "4"]); c.setCurrentText("1")
-        btn_add = QPushButton("+")
-        btn_rem = QPushButton("-")
+        btn_add = QPushButton("+"); btn_add.setFixedWidth(20)
+        btn_rem = QPushButton("-"); btn_rem.setFixedWidth(20)
         row_layout.addWidget(q)
         row_layout.addWidget(d)
         row_layout.addWidget(c)

--- a/src/section3d_view.py
+++ b/src/section3d_view.py
@@ -10,7 +10,7 @@ class Section3DView(QMainWindow):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setWindowTitle("Vista 3D")
+        self.setWindowTitle("Desarrollo de Refuerzo")
         central = QWidget()
         self.setCentralWidget(central)
         layout = QVBoxLayout(central)

--- a/src/view3d_window.py
+++ b/src/view3d_window.py
@@ -1,6 +1,13 @@
 """Simplified 2D/3D visualization for the beam design."""
 
-from PyQt5.QtWidgets import QMainWindow, QWidget, QVBoxLayout
+from PyQt5.QtWidgets import (
+    QMainWindow,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QLabel,
+)
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt
 
@@ -23,11 +30,19 @@ class View3DWindow(QMainWindow):
     def __init__(self, design):
         super().__init__()
         self.design = design
-        self.setWindowTitle("Vista 3D")
+        self.setWindowTitle("Desarrollo de Refuerzo")
 
         central = QWidget()
         self.setCentralWidget(central)
         layout = QVBoxLayout(central)
+
+        input_layout = QHBoxLayout()
+        input_layout.addWidget(QLabel("L (m)"))
+        self.le_length = QLineEdit("1.0")
+        self.le_length.setFixedWidth(60)
+        self.le_length.editingFinished.connect(self.draw_views)
+        input_layout.addWidget(self.le_length)
+        layout.addLayout(input_layout)
 
         self.fig = plt.figure(figsize=(8, 4), constrained_layout=True)
         self.ax2d = self.fig.add_subplot(1, 2, 1)
@@ -42,7 +57,7 @@ class View3DWindow(QMainWindow):
             b = float(self.design.edits["b (cm)"].text())
             h = float(self.design.edits["h (cm)"].text())
             r = float(self.design.edits["r (cm)"].text())
-            L = float(self.design.edits["L (m)"].text()) * 100
+            L = float(self.le_length.text()) * 100
         except ValueError:
             return
         de = DIAM_CM.get(self.design.cb_estribo.currentText(), 0)


### PR DESCRIPTION
## Summary
- move `L` input to the reinforcement window
- rename 3D view to "Desarrollo de Refuerzo"
- tweak rebar headers and controls
- document the new behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684aed2c1040832b99bf858a4f90da43