### PR TITLE
Remove 3D view; adjust bar placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ Consulta el archivo [DESARROLLO.md](DESARROLLO.md) para pautas sobre configuraci
 ## Desarrollo de Refuerzo
 
 Se añadió un botón **Desarrollo de Refuerzo** en la ventana de diseño que abre
-una representación simple de la viga. Esta ventana muestra una sección 2D y una
-vista tridimensional generada con Matplotlib. La longitud de la viga se ingresa
-en esta tercera ventana mediante el campo **L (m)**. Es una funcionalidad
+una representación simple de la viga. Actualmente solo se muestran los cortes de
+sección en M1, M2 y M3. La longitud de la viga se ingresa en esta ventana
+mediante el campo **L (m)** (sin efecto por ahora). Es una funcionalidad
 experimental que sirve como paso previo a la integración más completa descrita
 en [DESARROLLO_3D.md](DESARROLLO_3D.md).
 

--- a/src/design_window.py
+++ b/src/design_window.py
@@ -503,7 +503,7 @@ class DesignWindow(QMainWindow):
         # Sin mensaje emergente
 
     def show_view3d(self):
-        """Open a simple 2D/3D visualization window."""
+        """Open a window with cross-section views."""
         self.view3d = View3DWindow(self)
         self.view3d.show()
 


### PR DESCRIPTION
## Summary
- remove the 3D axes from the reinforcement window and keep only the section cuts
- keep the window but display sections M1, M2 and M3
- adjust bar spacing so bars remain inside the stirrup
- update button help text and README accordingly

## Testing
- `python -m py_compile src/view3d_window.py src/design_window.py`


------
https://chatgpt.com/codex/tasks/task_e_684b07492818832b969d07c533692154