### PR TITLE
Add translucent bars and reorder feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,14 @@ Consulta el archivo [DESARROLLO.md](DESARROLLO.md) para pautas sobre configuraci
 ## Desarrollo de Refuerzo
 
 Se añadió un botón **Desarrollo de Refuerzo** en la ventana de diseño que abre
-una representación simple de la viga. Actualmente solo se muestran los cortes de
+una representación simple de la viga. Actualmente se muestran los cortes de
 sección en M1, M2 y M3. La longitud de la viga se ingresa en esta ventana
-mediante el campo **L (m)** (sin efecto por ahora). Es una funcionalidad
-experimental que sirve como paso previo a la integración más completa descrita
-en [DESARROLLO_3D.md](DESARROLLO_3D.md).
+mediante el campo **L (m)** (sin efecto por ahora). Esta vista incluye una
+textura grisácea semitransparente para el concreto y las barras se sombrean con
+transparencia. Además es posible reordenar las barras de cada sección haciendo
+clic en una barra y utilizando las flechas izquierda/derecha del teclado.
+Es una funcionalidad experimental que sirve como paso previo a la integración
+más completa descrita en [DESARROLLO_3D.md](DESARROLLO_3D.md).
 
 ## Licencia
 


### PR DESCRIPTION
## Summary
- tweak concrete texture color
- shade rebar with transparency
- allow selecting a bar and moving it left/right
- document new behavior in README

## Testing
- `python -m py_compile src/view3d_window.py src/design_window.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684b0deb5114832b91128e95ae230fcf