### PR TITLE
Implement swap_bars helper and drag reorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,9 @@ sección en M1, M2 y M3. La longitud de la viga se ingresa en esta ventana
 mediante el campo **L (m)** (sin efecto por ahora). Esta vista incluye una
 textura grisácea semitransparente para el concreto y las barras se sombrean con
 transparencia. Además es posible reordenar las barras de cada sección haciendo
-clic en una barra y utilizando las flechas izquierda/derecha del teclado.
+clic en una barra y utilizando las flechas izquierda/derecha del teclado o
+arrastrándola a la posición deseada. Internamente la función `swap_bars` en
+`View3DWindow` permite intercambiar dos varillas de una sección.
 Es una funcionalidad experimental que sirve como paso previo a la integración
 más completa descrita en [DESARROLLO_3D.md](DESARROLLO_3D.md).
 


### PR DESCRIPTION
## Summary
- allow interactive bar order swapping with new `swap_bars` and `move_bar` helpers
- update `_distribute_x` docstring and 3D view to support dragging
- mention new functionality in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b147e7028832bab6b442c0020ab36