### PR TITLE
Add LaTeX memory export

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ Ventana 1: Ingreso de momentos → Diagramas superior/inferior → Corrección �
 
 Ventana 2: Visualización de viga con aceros → Selección de varillas → Resultados y verificación → Botón captura/exportar
 
+ETAPA 4 – MEMORIA DE CÁLCULO
+Muestra un resumen detallado de cada operación realizada en el diseño. Las fórmulas se presentan con notación LaTeX para una lectura clara e incluye botones para **Capturar**, **Exportar a PDF** o **Exportar a Word**.
+
 ## Requisitos de plataforma
 
 - Python 3.8 o superior instalado en el sistema.
@@ -162,6 +165,7 @@ Ventana 2: Visualización de viga con aceros → Selección de varillas → Resu
 
    Para funciones opcionales de captura o exportación a Word se pueden agregar
    `pyautogui` y `python-docx`.
+3. Para la visualización de fórmulas se recomienda contar con una distribución **LaTeX** instalada (TeX Live o similar).
 
 ## Ejecución
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ mplcursors
 pyqtgraph
 sympy
 python-docx
+pylatex

--- a/src/design_window.py
+++ b/src/design_window.py
@@ -16,6 +16,7 @@ from PyQt5.QtGui import QGuiApplication
 
 from .view3d_window import View3DWindow
 from .memoria_window import MemoriaWindow
+from .utils import latex_image
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt
 import numpy as np
@@ -537,11 +538,11 @@ class DesignWindow(QMainWindow):
         as_p = np.clip(as_p_raw, as_min, as_max)
 
         def frac(num: str, den: str) -> str:
-            return (
-                '<span style="display:inline-block; text-align:center; line-height:1;">'
-                f'<span style="border-bottom:1px solid; display:block">{num}</span>'
-                f'<span style="display:block">{den}</span></span>'
-            )
+            return f"\\dfrac{{{num}}}{{{den}}}"
+
+        frac_root_fc_fy = frac("\\sqrt{f'c}", "fy")
+        sqrt_fc = f"\\sqrt{{{fc}}}"
+        num_as_max = "0.85 f'c \\beta_1"
 
         lines = [
             "<h2>DATOS INGRESADOS</h2>",
@@ -555,28 +556,28 @@ class DesignWindow(QMainWindow):
             f"<p>ϕ varilla = {db} cm</p>",
             "<h2>CÁLCULOS</h2>",
             "<h3>Cálculo del peralte efectivo d</h3>",
-            (
-                f"<p class='eq'>d = h - r - ϕ_estribo - {frac('1', '2')} ϕ_barra = {h} - {r} - {de} - {frac('1', '2')}×{db} = <b>{d:.2f} cm</b></p>"
+            latex_image(
+                f"d = h - r - \\phi_{{estribo}} - {frac('1','2')} \\phi_{{barra}} = {h} - {r} - {de} - {frac('1','2')}\\times {db} = {d:.2f}\\,cm"
             ),
             "<h3>Cálculo de β<sub>1</sub></h3>",
             (
-                "<p class='eq'>β<sub>1</sub> = <b>0.85</b></p>"
+                latex_image("\\beta_{1} = 0.85")
                 if fc <= 280
-                else (
-                    f"<p class='eq'>β<sub>1</sub> = 0.85 - 0.05 × {frac(f'{fc}-280', '70')} = <b>{beta1:.3f}</b></p>"
+                else latex_image(
+                    f"\\beta_1 = 0.85 - 0.05\\times {frac(f'{fc}-280','70')} = {beta1:.3f}"
                 )
             ),
             "<h3>Cálculo de As_min</h3>",
-            (
-                f"<p class='eq'>A<sub>s,min</sub> = 0.7 × {frac('√f\'c', 'fy')} × b × d = 0.7 × {frac(f'√{fc}', str(fy))} × {b} × {d:.2f} = <b>{as_min:.2f} cm²</b></p>"
+            latex_image(
+                f"A_s,_{{min}} = 0.7\\times {frac_root_fc_fy}\\times b\\times d = 0.7\\times {frac(sqrt_fc, str(fy))}\\times {b}\\times {d:.2f} = {as_min:.2f}\\,cm^2"
             ),
             "<h3>Cálculo de As_max</h3>",
-            (
-                f"<p class='eq'>A<sub>s,max</sub> = 0.75 × {frac('0.85 f\'c β<sub>1</sub>', 'fy')} × {frac('6000', f'6000+{fy}')} × b × d = <b>{as_max:.2f} cm²</b></p>"
+            latex_image(
+                f"A_s,_{{max}} = 0.75\\times {frac(num_as_max,'fy')}\\times {frac('6000', f'6000+{fy}')}\\times b\\times d = {as_max:.2f}\\,cm^2"
             ),
             "<h3>Fórmula general para As</h3>",
-            (
-                f"<p class='eq'>A<sub>s</sub> = {frac('1.7 f\'c b d', '2 fy')} - {frac('1', '2')} √({frac('2.89 (f\'c b d)^2', 'fy^2')} - {frac('6.8 f\'c b M_u', 'φ fy^2')})</p>"
+            latex_image(
+                fr"A_s = {frac('1.7 f\'c b d','2 fy')} - {frac('1','2')}\sqrt{{{frac('2.89 (f\'c b d)^2','fy^2')} - {frac('6.8 f\'c b M_u','\\phi fy^2')}}}"
             ),
             "<h3>Detalle del cálculo de As por momento</h3>",
         ]
@@ -596,17 +597,16 @@ class DesignWindow(QMainWindow):
             )
             root = max(root, 0)
             calc = term - 0.5 * np.sqrt(root)
-            term_html = frac(f"1.7×{fc}×{b}×{d:.2f}", f"2×{fy}")
+            term_html = frac(f"1.7\\times{fc}\\times{b}\\times{d:.2f}", f"2\\times{fy}")
             root_html = (
-                f"{frac(f'2.89×({fc}×{b}×{d:.2f})²', f'{fy}²')} - "
-                f"{frac(f'6.8×{fc}×{b}×{Mu_kgcm:.0f}', f'{phi}×{fy}²')}"
+                f"{frac(f'2.89\\times({fc}\\times{b}\\times{d:.2f})^2', f'{fy}^2')} - "
+                f"{frac(f'6.8\\times{fc}\\times{b}\\times{Mu_kgcm:.0f}', f'{phi}\\times{fy}^2')}"
             )
             lines.extend(
                 [
                     f"<p><b>{lab}</b>: M<sub>u</sub> = {m:.2f} TN·m = {Mu_kgcm:.0f} kg·cm</p>",
-                    (
-                        "<p class='eq'>A<sub>s,calc</sub> = "
-                        f"{term_html} - {frac('1', '2')} √({root_html}) = {term:.2f} - {frac('1', '2')}√({root:.2f}) = <b>{calc:.2f} cm²</b></p>"
+                    latex_image(
+                        f"A_s,calc = {term_html} - {frac('1','2')}\\sqrt{{{root_html}}} = {term:.2f} - {frac('1','2')}\\sqrt{{{root:.2f}}} = {calc:.2f}\\,cm^2"
                     ),
                     f"<p>A<sub>s,req</sub> = <b>{a:.2f} cm²</b></p>",
                 ]

--- a/src/memoria_window.py
+++ b/src/memoria_window.py
@@ -1,7 +1,17 @@
 """Window displaying detailed calculation steps."""
 
-from PyQt5.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QPushButton, QTextEdit
+import os
+import tempfile
+from PyQt5.QtWidgets import (
+    QMainWindow,
+    QWidget,
+    QVBoxLayout,
+    QPushButton,
+    QTextEdit,
+    QFileDialog,
+)
 from PyQt5.QtGui import QGuiApplication
+from PyQt5.QtPrintSupport import QPrinter
 
 
 class MemoriaWindow(QMainWindow):
@@ -18,18 +28,51 @@ class MemoriaWindow(QMainWindow):
 
         self.text = QTextEdit()
         self.text.setReadOnly(True)
-        self.text.setFontFamily("Courier New")
-        self.text.setFontPointSize(10)
+        self.text.setFontFamily("Times New Roman")
+        self.text.setFontPointSize(11)
         # Text is provided as HTML to allow richer formatting
         self.text.setHtml(text)
         layout.addWidget(self.text)
 
         self.btn_capture = QPushButton("Capturar Memoria")
+        self.btn_export = QPushButton("Exportar…")
         self.btn_capture.clicked.connect(self._capture)
+        self.btn_export.clicked.connect(self.export)
         layout.addWidget(self.btn_capture)
+        layout.addWidget(self.btn_export)
 
     def _capture(self):
         pix = self.centralWidget().grab()
         QGuiApplication.clipboard().setPixmap(pix)
         # Sin mensaje emergente
+
+    def export(self):
+        """Save the memory view as PNG, PDF or DOCX."""
+        pix = self.centralWidget().grab()
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Guardar como",
+            "",
+            "PNG (*.png);;PDF (*.pdf);;Word (*.docx)",
+        )
+        if not path:
+            return
+        ext = os.path.splitext(path)[1].lower()
+        if ext == ".docx":
+            tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+            tmp.close()
+            pix.save(tmp.name)
+            from docx import Document
+
+            doc = Document()
+            doc.add_picture(tmp.name)
+            doc.save(path)
+            os.unlink(tmp.name)
+        elif ext == ".pdf":
+            printer = QPrinter(QPrinter.HighResolution)
+            printer.setOutputFormat(QPrinter.PdfFormat)
+            printer.setOutputFileName(path)
+            self.text.document().print_(printer)
+        else:
+            pix.save(path)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,26 @@
 """Helper utilities for unit conversions and styling."""
 
+import base64
+import io
+
+from matplotlib.figure import Figure
+
 
 def color_for_diameter(diam):
     """Return a color associated with a rebar diameter."""
     return "#000000"
+
+
+def latex_image(latex: str, fontsize: int = 12) -> str:
+    """Return an HTML ``<img>`` tag with a LaTeX expression rendered to PNG."""
+    fig = Figure(figsize=(0.01, 0.01))
+    ax = fig.add_subplot(111)
+    ax.axis("off")
+    ax.text(0.5, 0.5, f"${latex}$", ha="center", va="center", fontsize=fontsize)
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=300, bbox_inches="tight", transparent=True)
+    fig.clf()
+    data = base64.b64encode(buf.getvalue()).decode()
+    return f'<img src="data:image/png;base64,{data}"/>'
+
 


### PR DESCRIPTION
## Summary
- render LaTeX formulas as images in the calculation memory
- allow exporting the memory view to PNG, PDF or Word
- formalize memory text with Times New Roman
- add helper `latex_image` util
- document LaTeX requirement
- include `pylatex` in requirements

## Testing
- `python -m py_compile src/utils.py src/memoria_window.py src/design_window.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684c5dd67ae0832bba480a6ccc1329e1