### PR TITLE
Remove redundant activation check

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,13 +5,11 @@ import os
 import sys
 import ctypes
 
-from PyQt5.QtWidgets import QApplication, QDialog
+from PyQt5.QtWidgets import QApplication
 from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtCore import Qt
 
 from src.moment_app import MomentApp
-from src.activation import check_activation
-from src.activation_dialog import ActivationDialog
 
 
 
@@ -32,10 +30,6 @@ def main():
 
     app.setStyle("Fusion")
 
-    if not check_activation():
-        dlg = ActivationDialog()
-        if dlg.exec_() != QDialog.Accepted:
-            return
 
     # Keep a reference to the main window so it isn't garbage collected
     _window = MomentApp()


### PR DESCRIPTION
## Summary
- clear the main entry point by removing the activation dialog
- drop unused QDialog import

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9b5a9bf0832b9158efc9ed6d50fe