### PR TITLE
Disable splash screen for now

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,9 @@ from vigapp.activation.tk_dialog import run_activation
 # Toggle for enabling or disabling the license check. Set to ``True`` to
 # require activation again.
 ACTIVATION_ENABLED = False
+# Toggle the splash screen shown at startup. Set to ``False`` to
+# open the main window immediately.
+SPLASH_ENABLED = False
 
 
 
@@ -44,16 +47,23 @@ def main():
     if ACTIVATION_ENABLED and not run_activation():
         return
 
-    splash = QSplashScreen(QPixmap(icon_path).scaled(256, 256, Qt.KeepAspectRatio, Qt.SmoothTransformation))
-    splash.show()
+    if SPLASH_ENABLED:
+        splash = QSplashScreen(QPixmap(icon_path).scaled(
+            256, 256, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+        splash.show()
 
-    def show_main():
-        splash.close()
+        def show_main():
+            splash.close()
+            main_win = MenuWindow()
+            main_win.show()
+            app._window = main_win
+
+        QTimer.singleShot(2000, show_main)
+    else:
         main_win = MenuWindow()
         main_win.show()
         app._window = main_win
 
-    QTimer.singleShot(2000, show_main)
     sys.exit(app.exec_())
 
 


### PR DESCRIPTION
## Summary
- add `SPLASH_ENABLED` flag
- skip splash window when the flag is `False`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d899c7614832b95b949feb9c40463