### PR TITLE
Reduce LaTeX equation size

### DIFF
--- a/src/vigapp/models/utils.py
+++ b/src/vigapp/models/utils.py
@@ -11,17 +11,24 @@ def color_for_diameter(diam):
     return "#000000"
 
 
-def latex_image(latex: str, fontsize: int = 9) -> str:
+def latex_image(latex: str, fontsize: int = 8) -> str:
     """Return an HTML ``<img>`` tag with a LaTeX expression rendered to PNG."""
     fig = Figure(figsize=(0.01, 0.01))
     ax = fig.add_subplot(111)
     ax.axis("off")
     ax.text(0.5, 0.5, f"${latex}$", ha="center", va="center", fontsize=fontsize)
     buf = io.BytesIO()
-    fig.savefig(buf, format="png", dpi=300, bbox_inches="tight", transparent=True)
+    fig.savefig(
+        buf,
+        format="png",
+        dpi=200,
+        bbox_inches="tight",
+        pad_inches=0.0,
+        transparent=True,
+    )
     fig.clf()
     data = base64.b64encode(buf.getvalue()).decode()
-    style = "height:0.9em;vertical-align:middle;"
+    style = "height:0.8em;vertical-align:middle;"
     return f'<img src="data:image/png;base64,{data}" style="{style}"/>'
 
 


### PR DESCRIPTION
## Summary
- tweak latex_image to return smaller equations

## Testing
- `pytest -q` *(fails: No module named 'PyQt5', 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684d8c2fe108832b87386674595be4ec