### PR TITLE
Fix PDF generation path issues

### DIFF
--- a/src/pdf_engine/latex_renderer.py
+++ b/src/pdf_engine/latex_renderer.py
@@ -13,10 +13,18 @@ def render_report(title: str, data: Dict[str, Any], output_path: str = "reporte_
 
     # Ruta base segura al proyecto (sube 2 niveles desde /pdf_engine/)
     base_dir = Path(__file__).resolve().parents[2]
+    # Intenta usar la versión portátil incluida solo en Windows
     pdflatex_path = base_dir / "latex_runtime" / "texmfs" / "install" / "miktex" / "bin" / "x64" / "pdflatex.exe"
 
-    if not pdflatex_path.exists():
-        raise FileNotFoundError("No se encontró pdflatex en latex_runtime. Verifica que MiKTeX portátil esté instalado correctamente.")
+    if not pdflatex_path.exists() or not pdflatex_path.is_file():
+        # Si no existe, buscar pdflatex en el PATH del sistema
+        system_pdflatex = shutil.which("pdflatex")
+        if system_pdflatex:
+            pdflatex_path = Path(system_pdflatex)
+        else:
+            raise FileNotFoundError(
+                "No se encontró pdflatex. Instala una distribución LaTeX o coloca pdflatex en el PATH."
+            )
 
     # Preparar entorno Jinja2
     env = Environment(

--- a/src/pdf_engine/templates/reporte_flexion.tex
+++ b/src/pdf_engine/templates/reporte_flexion.tex
@@ -31,7 +31,7 @@ fy & {{ fy|default('')|escape }} MPa \\
 {% if section_img and section_img.strip() %}
 \begin{figure}[H]
 \centering
-\includegraphics[height=5cm]{ {{- section_img|escape -}} }
+\includegraphics[height=5cm]{\detokenize{ {{- section_img|escape -}} }}
 \end{figure}
 {% endif %}
 \end{minipage}
@@ -49,7 +49,7 @@ Valor calculado: \( d = {{ d }}\,\text{m} \)
 {% if peralte_img and peralte_img.strip() %}
 \begin{figure}[H]
 \centering
-\includegraphics[width=0.5\textwidth]{ {{- peralte_img|escape -}} }
+\includegraphics[width=0.5\textwidth]{\detokenize{ {{- peralte_img|escape -}} }}
 \end{figure}
 {% endif %}
 
@@ -66,7 +66,7 @@ Valor calculado: \( \beta_1 = {{ b1 }} \)
 {% if b1_img and b1_img.strip() %}
 \begin{figure}[H]
 \centering
-\includegraphics[width=0.5\textwidth]{ {{- b1_img|escape -}} }
+\includegraphics[width=0.5\textwidth]{\detokenize{ {{- b1_img|escape -}} }}
 \end{figure}
 {% endif %}
 
@@ -83,7 +83,7 @@ Valor calculado: \( P_{bal} = {{ pbal }} \)
 {% if pbal_img and pbal_img.strip() %}
 \begin{figure}[H]
 \centering
-\includegraphics[width=0.5\textwidth]{ {{- pbal_img|escape -}} }
+\includegraphics[width=0.5\textwidth]{\detokenize{ {{- pbal_img|escape -}} }}
 \end{figure}
 {% endif %}
 
@@ -100,7 +100,7 @@ Valor calculado: \( \rho_{bal} = {{ rhobal }} \)
 {% if rhobal_img and rhobal_img.strip() %}
 \begin{figure}[H]
 \centering
-\includegraphics[width=0.5\textwidth]{ {{- rhobal_img|escape -}} }
+\includegraphics[width=0.5\textwidth]{\detokenize{ {{- rhobal_img|escape -}} }}
 \end{figure}
 {% endif %}
 
@@ -117,7 +117,7 @@ Valor calculado: \( P_{max} = {{ pmax }} \)
 {% if pmax_img and pmax_img.strip() %}
 \begin{figure}[H]
 \centering
-\includegraphics[width=0.5\textwidth]{ {{- pmax_img|escape -}} }
+\includegraphics[width=0.5\textwidth]{\detokenize{ {{- pmax_img|escape -}} }}
 \end{figure}
 {% endif %}
 
@@ -134,7 +134,7 @@ Valor calculado: \( A_{s}^{\text{min}} = {{ as_min }} \)
 {% if asmin_img and asmin_img.strip() %}
 \begin{figure}[H]
 \centering
-\includegraphics[width=0.5\textwidth]{ {{- asmin_img|escape -}} }
+\includegraphics[width=0.5\textwidth]{\detokenize{ {{- asmin_img|escape -}} }}
 \end{figure}
 {% endif %}
 
@@ -151,7 +151,7 @@ Valor calculado: \( A_{s}^{\text{max}} = {{ as_max }} \)
 {% if asmax_img and asmax_img.strip() %}
 \begin{figure}[H]
 \centering
-\includegraphics[width=0.5\textwidth]{ {{- asmax_img|escape -}} }
+\includegraphics[width=0.5\textwidth]{\detokenize{ {{- asmax_img|escape -}} }}
 \end{figure}
 {% endif %}
 


### PR DESCRIPTION
## Summary
- escape paths with `\detokenize` in LaTeX templates to allow spaces
- look for `pdflatex` in PATH when the bundled executable is missing

## Testing
- `pytest -k calc_as_req_sample -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_68522649de6c832bb67b08d6292962c7