### PR TITLE
Fix LaTeX image paths

### DIFF
--- a/src/pdf_engine/latex_renderer.py
+++ b/src/pdf_engine/latex_renderer.py
@@ -103,6 +103,15 @@ def render_report(title: str, data: Dict[str, Any], output_path: str = "reporte_
         else:
             context[key] = None
 
+    if "images" in context and isinstance(context["images"], (list, tuple)):
+        normalized_list = []
+        for img in context["images"]:
+            if isinstance(img, str) and img.strip():
+                normalized_list.append(img.replace("\\", "/"))
+            else:
+                normalized_list.append(img)
+        context["images"] = normalized_list
+
     debug_tex = base_dir / "debug_report.tex"
 
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/src/pdf_engine/templates/reporte_flexion.tex
+++ b/src/pdf_engine/templates/reporte_flexion.tex
@@ -32,7 +32,7 @@ fy & {{ fy|default('')|escape }} \\
 {% if section_img %}
 \begin{figure}[H]
 \centering
-\includegraphics[height=5cm]{ {{ section_img }} }
+\includegraphics[height=5cm]{ {{- section_img -}} }
 \end{figure}
 {% endif %}
 \end{minipage}
@@ -63,7 +63,7 @@ fy & {{ fy|default('')|escape }} \\
 {% for img in images %}
 \begin{figure}[H]
 \centering
-\includegraphics[width=0.9\textwidth]{ {{ img }} }
+\includegraphics[width=0.9\textwidth]{ {{- img -}} }
 \end{figure}
 {% endfor %}
 


### PR DESCRIPTION
## Summary
- handle Windows style paths in image lists
- trim whitespace around image placeholders in LaTeX template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538fc34db0832b99d5723dd5c6d4e9