### PR TITLE
Fix color mapping initialization

### DIFF
--- a/report_section_flex_dxf.py
+++ b/report_section_flex_dxf.py
@@ -25,6 +25,14 @@ _COLOR_MAP = {
     "white": 7,
 }
 
+
+def _color_index(color: str | int) -> int:
+    """Return a valid DXF color index for ``color``."""
+    if isinstance(color, int):
+        return int(color)
+    return _COLOR_MAP.get(str(color).lower(), 7)
+
+
 # Mapping of bar diameter keys to primary colors (red, blue, yellow)
 _COLOR_ORDER = ["red", "blue", "yellow"]
 DIAM_COLOR = {
@@ -32,13 +40,6 @@ DIAM_COLOR = {
     for i, key in enumerate(DIAM_CM.keys())
 }
 DIAM_COLOR_IDX = {k: _color_index(c) for k, c in DIAM_COLOR.items()}
-
-
-def _color_index(color: str | int) -> int:
-    """Return a valid DXF color index for ``color``."""
-    if isinstance(color, int):
-        return int(color)
-    return _COLOR_MAP.get(str(color).lower(), 7)
 
 
 def _bars_summary(bars: Iterable[Dict]) -> str:


### PR DESCRIPTION
## Summary
- ensure `_color_index` is defined before creating `DIAM_COLOR_IDX`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598031f5e8832ba774692bd281b559