### PR TITLE
Enable standalone shear design

### DIFF
--- a/tests/test_shear_window.py
+++ b/tests/test_shear_window.py
@@ -2,18 +2,14 @@ import os
 import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from PyQt5.QtWidgets import QApplication
-from vigapp.ui.design_window import DesignWindow
 from vigapp.ui.shear_window import ShearDesignWindow
-import numpy as np
 
 
 def test_shear_diagram_offscreen(monkeypatch):
     monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
     app = QApplication([])
-    mn = np.array([-10.0, -15.0, -20.0])
-    mp = np.array([5.0, 10.0, 15.0])
-    design = DesignWindow(mn, mp, show_window=False)
-    shear = ShearDesignWindow(design, show_window=False)
+    shear = ShearDesignWindow(None, show_window=False)
     shear.ed_vu.setText("30")
     shear.ed_ln.setText("6")
+    shear.ed_d.setText("50")
     shear.draw_diagram()

--- a/vigapp/ui/menu_window.py
+++ b/vigapp/ui/menu_window.py
@@ -338,14 +338,12 @@ class MenuWindow(QMainWindow):
         generar_reporte_html(datos, resultados, tabla, imagenes, seccion, dev_as)
 
     def open_cortante(self):
-        if not hasattr(self, "design_page"):
-            QMessageBox.warning(self, "Advertencia", "Primero complete el diseño por flexión")
-            return
+        design_win = getattr(self, "design_page", None)
         self.cortante_page = ShearDesignWindow(
-            self.design_page,
+            design_win,
             show_window=False,
             menu_callback=self.show_menu,
-            back_callback=self.show_design,
+            back_callback=self.show_design if design_win else None,
         )
         self.stacked.addWidget(self.cortante_page)
         self.stacked.setCurrentWidget(self.cortante_page)

--- a/vigapp/ui/shear_window.py
+++ b/vigapp/ui/shear_window.py
@@ -21,7 +21,7 @@ from ..graphics.shear_scheme import draw_shear_scheme
 class ShearDesignWindow(QMainWindow):
     """UI to input Vu and plot a linear shear diagram."""
 
-    def __init__(self, design_win, parent=None, *, show_window=True,
+    def __init__(self, design_win=None, parent=None, *, show_window=True,
                  menu_callback=None, back_callback=None):
         super().__init__(parent)
         self.design_win = design_win
@@ -48,9 +48,14 @@ class ShearDesignWindow(QMainWindow):
         self.cb_type = QComboBox()
         self.cb_type.addItems(["Apoyada", "Volado"])
 
-        d_val = self.design_win.calc_effective_depth()
-        self.ed_d = QLineEdit(f"{d_val:.2f}")
-        self.ed_d.setReadOnly(True)
+        if self.design_win is not None:
+            d_val = self.design_win.calc_effective_depth()
+            self.ed_d = QLineEdit(f"{d_val:.2f}")
+            self.ed_d.setReadOnly(True)
+        else:
+            d_val = 50.0
+            self.ed_d = QLineEdit(f"{d_val:.2f}")
+            self.ed_d.setReadOnly(False)
         self.ed_d.setAlignment(Qt.AlignRight)
 
         layout.addWidget(QLabel("Vu (T)"), 0, 0)


### PR DESCRIPTION
## Summary
- allow ShearDesignWindow to work without a DesignWindow
- remove flexural-design requirement from menu action
- update shear diagram test

## Testing
- `pytest tests/test_shear_window.py -q`
- `pytest tests/test_design_window.py -q`
- `pytest tests/test_shear_design.py -q`
- `pytest tests/test_moment_app.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c3c117f8832b958493f3e49919cc