### PR TITLE
Update flexion report wording

### DIFF
--- a/reporte_flexion_html.py
+++ b/reporte_flexion_html.py
@@ -72,7 +72,8 @@ def generar_reporte_html(
     ]
 
     for k, v in datos.items():
-        html.append(f"<tr><td><b>{k}</b></td><td>{_fmt(v)}</td></tr>")
+        label = "h" if k in ("h (cm)", "Altura (h)", "Alto", "ALTO") else k
+        html.append(f"<tr><td><b>{label}</b></td><td>{_fmt(v)}</td></tr>")
     html.extend(
         [
             "</table>",
@@ -85,12 +86,12 @@ def generar_reporte_html(
     )
 
     orden = [
-        ("Cal. de Peralte <span class='norma'>(E060 Art. 17.5.2)</span>", "peralte"),
-        ("Cal. de β1 <span class='norma'>(E060 Art. 10.2.7.3)</span>", "b1"),
+        ("Calculo de Peralte <span class='norma'>(E060 Art. 17.5.2)</span>", "peralte"),
+        ("Calculo de β1 <span class='norma'>(E060 Art. 10.2.7.3)</span>", "b1"),
         ("\u03c1<sub>bal</sub> <span class='norma'>(E060 Art. 10.3.32)</span>", "pbal"),
         ("\u03c1<sub>max</sub> <span class='norma'>(E060 Art. 10.3.4)</span>", "pmax"),
-        ("Cal. de As m\u00edn <span class='norma'>(E060 Art. 10.5.2)</span>", "as_min"),
-        ("Cal. de As m\u00e1x <span class='norma'>(E060 Art. 10.3.4)</span>", "as_max"),
+        ("Calculo de As m\u00edn <span class='norma'>(E060 Art. 10.5.2)</span>", "as_min"),
+        ("Calculo de As m\u00e1x <span class='norma'>(E060 Art. 10.3.4)</span>", "as_max"),
     ]
 
     html.append("<h2>C\u00c1LCULOS</h2>")
@@ -124,7 +125,7 @@ def generar_reporte_html(
             )
 
     if calc_sections:
-        html.append("<h2>DESARROLLO AS REQUERIDO</h2>")
+        html.append("<h2>CALCULO DE AS REQUERIDO</h2>")
         for tit, formulas in calc_sections:
             sec_id += 1
             hid = f"h{sec_id}"
@@ -141,10 +142,10 @@ def generar_reporte_html(
         html.append("</div><div class='page'>")
 
     if tabla:
-        html.append("<h2>Resumen de Verificaci\u00f3n</h2>")
+        html.append("<h2>RESUMEN DE ACERO</h2>")
         html.append("<table>")
         html.append(
-            "<tr><th>Secci\u00f3n</th><th>As requerido</th><th>As dise\u00f1ado</th><th>Estado</th></tr>"
+            "<tr><th>Secci\u00f3n</th><th>AS REQUERIDO</th><th>AS DISE\u00d1O</th><th>Estado</th></tr>"
         )
         as_min = float(resultados.get("as_min", {}).get("valor", 0))  # Asegúrate de tenerlo definido
 

--- a/vigapp/pdf_engine/templates/reporte_flexion.tex
+++ b/vigapp/pdf_engine/templates/reporte_flexion.tex
@@ -17,7 +17,7 @@
 \begin{tabular}{|l|c|}
 \hline
 Base (b) & {{ base|default('')|escape }} m \\
-Altura (h) & {{ altura|default('')|escape }} m \\
+h & {{ altura|default('')|escape }} m \\
 Recubrimiento (r) & {{ recubrimiento|default('')|escape }} m \\
 Estribo (\ensuremath{\phi_e}) & {{ diam_estribo|default('')|escape }} m \\
 Varilla principal (\ensuremath{\phi_s}) & {{ diam_varilla|default('')|escape }} m \\

--- a/vigapp/ui/design_window.py
+++ b/vigapp/ui/design_window.py
@@ -432,7 +432,7 @@ class DesignWindow(QMainWindow):
 
         data_section = [
             ["b (cm)", f"{b}"],
-            ["h (cm)", f"{h}"],
+            ["h", f"{h}"],
             ["r (cm)", f"{r}"],
             ["f'c (kg/cm²)", f"{fc}"],
             ["fy (kg/cm²)", f"{fy}"],
@@ -518,7 +518,7 @@ class DesignWindow(QMainWindow):
             calc = term - 0.5 * np.sqrt(root)
             calc_sections.append(
                 (
-                    f"As para {lab}",
+                    f"Calculo para {lab}",
                     [
                         rf"$M_u = {m:.2f}\,\text{{TN·m}} = {Mu_kgcm:.0f}\,\text{{kg·cm}}$",
                         rf"$A_s^{{\text{{calc}}}} = {calc:.2f}\,\text{{cm}}^2$",


### PR DESCRIPTION
## Summary
- tweak labels in design window data section
- rename calculations and summary headings in flexion HTML report
- adjust height label in LaTeX template
- replace "As para" sections with "Calculo para" in reports

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872c4a82960832b85fd2578b2feacd8