### PR TITLE
Add beam section view in shear design window

### DIFF
--- a/README_SHEAR.md
+++ b/README_SHEAR.md
@@ -3,6 +3,8 @@
 
 Este módulo realiza el diseño por corte para vigas de concreto armado según normativa vigente. Está basado en el esquema de distribución mínima de estribos para vigas **tipo Dual 1 y Dual 2**, y considera casos de **vigas apoyadas o voladas**.
 
+La ventana de diseño por corte muestra ahora lateralmente la sección de la viga con sus dimensiones básicas y los diámetros seleccionados de varilla y estribo.
+
 ---
 
 ## 1. DATOS DE ENTRADA

--- a/tests/test_shear_window.py
+++ b/tests/test_shear_window.py
@@ -25,3 +25,11 @@ def test_shear_diagram_offscreen(monkeypatch):
     shear2.draw_diagram()
     assert not shear2.ed_d.isReadOnly()
     app.quit()
+
+
+def test_section_canvas_exists(monkeypatch):
+    monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication([])
+    shear = ShearDesignWindow(None, show_window=False)
+    assert hasattr(shear, "canvas_sec")
+    app.quit()

--- a/vigapp/ui/shear_window.py
+++ b/vigapp/ui/shear_window.py
@@ -16,6 +16,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 import matplotlib.pyplot as plt
 
 from ..graphics.shear_scheme import draw_shear_scheme
+from .design.plots import draw_section
 
 
 class ShearDesignWindow(QMainWindow):
@@ -29,7 +30,8 @@ class ShearDesignWindow(QMainWindow):
         self.back_callback = back_callback
         self.setWindowTitle("Dise\u00f1o por Cortante")
         self._build_ui()
-        self.resize(600, 500)
+        # Wider window to display the beam section alongside the inputs
+        self.resize(850, 500)
         if show_window:
             self.show()
 
@@ -75,6 +77,14 @@ class ShearDesignWindow(QMainWindow):
         self.canvas = FigureCanvas(self.fig)
         layout.addWidget(self.canvas, 5, 0, 1, 2)
 
+        # Section figure displayed on the right side
+        self.fig_sec, self.ax_sec = plt.subplots(figsize=(3, 3), constrained_layout=True)
+        self.canvas_sec = FigureCanvas(self.fig_sec)
+        layout.addWidget(self.canvas_sec, 0, 2, 5, 1)
+        self.lbl_props = QLabel("")
+        self.lbl_props.setAlignment(Qt.AlignTop | Qt.AlignHCenter)
+        layout.addWidget(self.lbl_props, 5, 2)
+
         self.ed_vu.editingFinished.connect(self.draw_diagram)
         self.ed_ln.editingFinished.connect(self.draw_diagram)
         btn_menu.clicked.connect(self.on_menu)
@@ -82,6 +92,7 @@ class ShearDesignWindow(QMainWindow):
         self.cb_type.currentIndexChanged.connect(self.draw_diagram)
 
         self.draw_diagram()
+        self.update_section()
 
     # ------------------------------------------------------------------
     def draw_diagram(self):
@@ -97,6 +108,7 @@ class ShearDesignWindow(QMainWindow):
 
         draw_shear_scheme(self.ax, Vu, L, d, beam_type)
         self.canvas.draw()
+        self.update_section()
 
     # ------------------------------------------------------------------
     def on_menu(self):
@@ -111,5 +123,35 @@ class ShearDesignWindow(QMainWindow):
             parent = self.parent()
             if parent:
                 parent.show()
+
+    # ------------------------------------------------------------------
+    def update_section(self):
+        """Draw beam section and show basic properties."""
+        if self.design_win is not None:
+            try:
+                b = float(self.design_win.edits["b (cm)"].text())
+                h = float(self.design_win.edits["h (cm)"].text())
+                r = float(self.design_win.edits["r (cm)"].text())
+                bar = self.design_win.cb_varilla.currentText()
+                stirrup = self.design_win.cb_estribo.currentText()
+            except Exception:
+                return
+        else:
+            b = 30.0
+            h = 50.0
+            r = 4.0
+            bar = '5/8"'
+            stirrup = '3/8"'
+
+        try:
+            d = float(self.ed_d.text())
+        except ValueError:
+            d = 0.0
+
+        draw_section(self.ax_sec, b, h, r, d)
+        self.canvas_sec.draw()
+        self.lbl_props.setText(
+            f"h={h:.0f} cm  d={d:.1f} cm  \u03c6 {bar}  \u03c6e {stirrup}"
+        )
 
 


### PR DESCRIPTION
## Summary
- add lateral section display in ShearDesignWindow
- widen the window for new canvas
- show basic section properties next to diagram
- mention update in shear design README
- test that section canvas is created

## Testing
- `pytest tests/test_shear_window.py::test_shear_diagram_offscreen -q`
- `pytest tests/test_shear_window.py::test_section_canvas_exists -q`
- `pytest tests/test_design_window.py -q`
- `pytest tests/test_moment_app.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c68ae2dc832b93f17271625f1b26