### PR TITLE
Add unit for h and include d in report

### DIFF
--- a/reporte_flexion_html.py
+++ b/reporte_flexion_html.py
@@ -71,11 +71,24 @@ def generar_reporte_html(
         "<table style='margin: 0;'>",
     ]
 
+    units = {
+        "b (cm)": "cm",
+        "h (cm)": "cm",
+        "d (cm)": "cm",
+        "r (cm)": "cm",
+        "f'c (kg/cm²)": "kg/cm²",
+        "fy (kg/cm²)": "kg/cm²",
+        "ϕ estribo (cm)": "cm",
+        "ϕ varilla (cm)": "cm",
+    }
+
     for k, v in datos.items():
-        label = (
-            "h (cm)" if k in ("h", "Altura (h)", "Alto", "ALTO") else k
-        )
-        html.append(f"<tr><td><b>{label}</b></td><td>{_fmt(v)}</td></tr>")
+        label = "h (cm)" if k in ("h", "Altura (h)", "Alto", "ALTO") else k
+        val = _fmt(v)
+        unit = units.get(label)
+        if unit:
+            val = f"{val} {unit}"
+        html.append(f"<tr><td><b>{label}</b></td><td>{val}</td></tr>")
     html.extend(
         [
             "</table>",

--- a/vigapp/pdf_engine/templates/reporte_flexion.tex
+++ b/vigapp/pdf_engine/templates/reporte_flexion.tex
@@ -18,6 +18,7 @@
 \hline
 Base (b) & {{ base|default('')|escape }} m \\
 h (m) & {{ altura|default('')|escape }} m \\
+d (m) & {{ (d/100)|default('')|escape }} m \\
 Recubrimiento (r) & {{ recubrimiento|default('')|escape }} m \\
 Estribo (\ensuremath{\phi_e}) & {{ diam_estribo|default('')|escape }} m \\
 Varilla principal (\ensuremath{\phi_s}) & {{ diam_varilla|default('')|escape }} m \\

--- a/vigapp/ui/design_window.py
+++ b/vigapp/ui/design_window.py
@@ -433,6 +433,7 @@ class DesignWindow(QMainWindow):
         data_section = [
             ["b (cm)", f"{b}"],
             ["h (cm)", f"{h}"],
+            ["d (cm)", f"{d:.2f}"],
             ["r (cm)", f"{r}"],
             ["f'c (kg/cm²)", f"{fc}"],
             ["fy (kg/cm²)", f"{fy}"],


### PR DESCRIPTION
## Summary
- show cm unit next to the height value in the HTML report
- include effective depth `d` in the HTML and LaTeX report tables

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6872c9e7990c832b95cf4742037b7d63