### PR TITLE
Adjust shear diagram graphics

### DIFF
--- a/vigapp/graphics/shear_scheme.py
+++ b/vigapp/graphics/shear_scheme.py
@@ -66,7 +66,7 @@ def draw_shear_scheme(ax: plt.Axes, Vu: float, ln: float, d: float, beam_type: s
     column_h = 2.0
     y0 = 0
     margin = ln * 0.1
-    arrow_len = margin * 0.4
+    arrow_len = 0.25
     dim_y1 = y0 - margin * 0.2
     dim_y2 = y0 - margin * 0.4
 
@@ -99,9 +99,9 @@ def draw_shear_scheme(ax: plt.Axes, Vu: float, ln: float, d: float, beam_type: s
         x_vu = ln - d
         ax.annotate(
             "",
-            xy=(x_vu, h),
-            xytext=(x_vu, h + arrow_len),
-            arrowprops=dict(arrowstyle="-|>", color="red", lw=2),
+            xy=(x_vu + arrow_len / 2, h + arrow_len),
+            xytext=(x_vu - arrow_len / 2, h + arrow_len),
+            arrowprops=dict(arrowstyle="<->", color="red", lw=2),
         )
         ax.text(
             x_vu,
@@ -115,8 +115,7 @@ def draw_shear_scheme(ax: plt.Axes, Vu: float, ln: float, d: float, beam_type: s
 
         ax.plot([0, ln], [0, h], color="blue", lw=1)
 
-        _dim_line(ax, x_vu, ln, dim_y1, "d")
-        _dim_vline(ax, h, h + arrow_len, x_vu + 0.1, "d")
+        _dim_vline(ax, 0, h, -support_w - margin * 0.3, "h")
         _dim_line(ax, 0, ln, dim_y2, f"ln = {ln:.2f} m")
 
         ax.set_xlim(-support_w - margin, ln + margin)
@@ -162,9 +161,9 @@ def draw_shear_scheme(ax: plt.Axes, Vu: float, ln: float, d: float, beam_type: s
         for x_vu in (x_vu_left, x_vu_right):
             ax.annotate(
                 "",
-                xy=(x_vu, h),
-                xytext=(x_vu, h + arrow_len),
-                arrowprops=dict(arrowstyle="-|>", color="red", lw=2),
+                xy=(x_vu + arrow_len / 2, h + arrow_len),
+                xytext=(x_vu - arrow_len / 2, h + arrow_len),
+                arrowprops=dict(arrowstyle="<->", color="red", lw=2),
             )
             ax.text(
                 x_vu,
@@ -176,15 +175,12 @@ def draw_shear_scheme(ax: plt.Axes, Vu: float, ln: float, d: float, beam_type: s
                 fontsize=9,
             )
 
-        _dim_vline(ax, h, h + arrow_len, x_vu_left + 0.1, "d")
-
         # Compression line
         ax.plot([0, ln], [h, 0], color="blue", lw=1)
 
 
         # Dimension lines
-        _dim_line(ax, 0, d, dim_y1, "d")
-        _dim_line(ax, ln / 2, ln, dim_y1, "ln/2")
+        _dim_vline(ax, 0, h, -margin * 0.3, "h")
         _dim_line(ax, 0, ln, dim_y2, f"ln = {ln:.2f} m")
 
         ax.set_xlim(-margin, ln + margin)

--- a/vigapp/ui/shear_window.py
+++ b/vigapp/ui/shear_window.py
@@ -46,8 +46,10 @@ class ShearDesignWindow(QMainWindow):
 
         self.ed_vu = QLineEdit("0.0")
         self.ed_vu.setAlignment(Qt.AlignRight)
+        self.ed_vu.setFixedWidth(70)
         self.ed_ln = QLineEdit("5.0")
         self.ed_ln.setAlignment(Qt.AlignRight)
+        self.ed_ln.setFixedWidth(70)
         self.cb_type = QComboBox()
         self.cb_type.addItems(["Apoyada", "Volado"])
 
@@ -72,12 +74,16 @@ class ShearDesignWindow(QMainWindow):
 
         self.ed_b = QLineEdit(b_def)
         self.ed_b.setAlignment(Qt.AlignRight)
+        self.ed_b.setFixedWidth(70)
         self.ed_h = QLineEdit(h_def)
         self.ed_h.setAlignment(Qt.AlignRight)
+        self.ed_h.setFixedWidth(70)
         self.ed_fc = QLineEdit(fc_def)
         self.ed_fc.setAlignment(Qt.AlignRight)
+        self.ed_fc.setFixedWidth(70)
         self.ed_fy = QLineEdit(fy_def)
         self.ed_fy.setAlignment(Qt.AlignRight)
+        self.ed_fy.setFixedWidth(70)
 
         self.cb_varilla = QComboBox()
         self.cb_varilla.addItems(['1/2"', '5/8"', '3/4"', '1"'])
@@ -94,6 +100,7 @@ class ShearDesignWindow(QMainWindow):
         self.ed_d = QLineEdit()
         self.ed_d.setReadOnly(True)
         self.ed_d.setAlignment(Qt.AlignRight)
+        self.ed_d.setFixedWidth(70)
 
         layout.addWidget(QLabel("Vu (T)"), 0, 0)
         layout.addWidget(self.ed_vu, 0, 1)


### PR DESCRIPTION
## Summary
- draw Vu as a horizontal arrow and keep arrow height constant
- show beam height (h) instead of d on the shear scheme
- shrink shear design input boxes

## Testing
- `pytest tests/test_shear_window.py::test_section_canvas_exists -q`
- `pytest tests/test_shear_window.py::test_shear_diagram_offscreen -q`
- `pytest tests/test_shear_window.py -k "section_canvas_exists or shear_diagram_offscreen" -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6876cf8c4f24832bbf4f71eeaf2ac295