### PR TITLE
Implement shear design with export options

### DIFF
--- a/tests/test_shear_window.py
+++ b/tests/test_shear_window.py
@@ -16,13 +16,15 @@ def test_shear_diagram_offscreen(monkeypatch):
     shear = ShearDesignWindow(design, show_window=False)
     shear.ed_vu.setText("30")
     shear.ed_ln.setText("6")
-    shear.draw_diagram()
+    shear.calculate()
     assert shear.ed_d.isReadOnly()
+    assert shear.btn_pdf.isEnabled()
+    assert shear.btn_dxf.isEnabled()
 
     shear2 = ShearDesignWindow(None, show_window=False)
     shear2.ed_vu.setText("30")
     shear2.ed_ln.setText("6")
-    shear2.draw_diagram()
+    shear2.calculate()
     assert shear2.ed_d.isReadOnly()
     app.quit()
 

--- a/vigapp/graphics/shear_dxf.py
+++ b/vigapp/graphics/shear_dxf.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from .utilities import _require_ezdxf
+
+try:  # pragma: no cover
+    import ezdxf  # type: ignore
+except Exception:  # pragma: no cover
+    ezdxf = None
+
+
+def _structure_points(ln: float, h: float, beam_type: str) -> list[tuple[float, float]]:
+    support_w = 0.5
+    column_h = 2.0
+    y0 = 0.0
+    if beam_type == "volado":
+        return [
+            (-support_w, y0 - column_h),
+            (0, y0 - column_h),
+            (0, y0),
+            (ln, y0),
+            (ln, y0 + h),
+            (0, y0 + h),
+            (-support_w, y0 + h),
+        ]
+    return [
+        (-support_w, y0 - column_h),
+        (0, y0 - column_h),
+        (0, y0),
+        (ln, y0),
+        (ln, y0 - column_h),
+        (ln + support_w, y0 - column_h),
+        (ln + support_w, y0 + h),
+        (ln, y0 + h),
+        (0, y0 + h),
+        (-support_w, y0 + h),
+    ]
+
+
+def export_shear_dxf(filename: str, Vu: float, ln: float, d: float, h: float, beam_type: str) -> None:
+    """Export shear scheme to a DXF file."""
+    _require_ezdxf()
+    doc = ezdxf.new()
+    msp = doc.modelspace()
+
+    for name, color in {
+        "Estructura": 7,
+        "Cargas": 1,
+        "Diagrama": 5,
+        "Texto": 7,
+        "Cotas": 7,
+    }.items():
+        if name not in doc.layers:
+            doc.layers.new(name, dxfattribs={"color": color})
+
+    pts = _structure_points(ln, h, beam_type)
+    msp.add_lwpolyline(pts, dxfattribs={"layer": "Estructura", "closed": True})
+
+    if beam_type == "volado":
+        msp.add_line((0, h), (ln, 0), dxfattribs={"layer": "Diagrama"})
+        x = d
+        msp.add_line((x, h), (x, h - d), dxfattribs={"layer": "Cargas"})
+        msp.add_text("Vu", dxfattribs={"height": 0.2, "layer": "Texto"}).set_placement((x, h + 0.2))
+    else:
+        msp.add_line((0, 0), (ln, h), dxfattribs={"layer": "Diagrama"})
+        for x in (d, ln - d):
+            msp.add_line((x, h), (x, h - d), dxfattribs={"layer": "Cargas"})
+            msp.add_text("Vu", dxfattribs={"height": 0.2, "layer": "Texto"}).set_placement((x, h + 0.2))
+
+    doc.saveas(filename)

--- a/vigapp/graphics/shear_scheme.py
+++ b/vigapp/graphics/shear_scheme.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import matplotlib.pyplot as plt
-from matplotlib.patches import Rectangle
+from matplotlib.patches import Polygon
 
 
 def _dim_vline(ax, y1, y2, x, label, offset=0.05):
@@ -43,7 +43,9 @@ def _dim_line(ax, x1, x2, y, label, offset=0.15):
     )
 
 
-def draw_shear_scheme(ax: plt.Axes, Vu: float, ln: float, d: float, beam_type: str = "apoyada") -> None:
+def draw_shear_scheme(
+    ax: plt.Axes, Vu: float, ln: float, d: float, h: float, beam_type: str = "apoyada"
+) -> None:
     """Draw a simple shear scheme on ``ax``.
 
     Parameters
@@ -61,7 +63,6 @@ def draw_shear_scheme(ax: plt.Axes, Vu: float, ln: float, d: float, beam_type: s
     """
     ax.clear()
 
-    h = 0.4
     support_w = 0.5
     column_h = 2.0
     y0 = 0
@@ -70,122 +71,62 @@ def draw_shear_scheme(ax: plt.Axes, Vu: float, ln: float, d: float, beam_type: s
     dim_y1 = y0 - margin * 0.2
     dim_y2 = y0 - margin * 0.4
 
-    # Beam rectangle and supports
+    structure_pts: list[tuple[float, float]]
     if beam_type == "volado":
-        ax.add_patch(
-            Rectangle(
-                (0, y0),
-                ln,
-                h,
-                edgecolor="black",
-                facecolor="0.9",
-                linewidth=1,
-                zorder=1,
-            )
-        )
-        ax.add_patch(
-            Rectangle(
-                (-support_w, y0 - column_h),
-                support_w,
-                column_h + h,
-                facecolor="0.85",
-                edgecolor="black",
-                hatch="//",
-                linewidth=1,
-                zorder=2,
-            )
-        )
+        structure_pts = [
+            (-support_w, y0 - column_h),
+            (0, y0 - column_h),
+            (0, y0),
+            (ln, y0),
+            (ln, y0 + h),
+            (0, y0 + h),
+            (-support_w, y0 + h),
+        ]
+    else:
+        structure_pts = [
+            (-support_w, y0 - column_h),
+            (0, y0 - column_h),
+            (0, y0),
+            (ln, y0),
+            (ln, y0 - column_h),
+            (ln + support_w, y0 - column_h),
+            (ln + support_w, y0 + h),
+            (ln, y0 + h),
+            (0, y0 + h),
+            (-support_w, y0 + h),
+        ]
 
-        x_vu = ln - d
-        ax.annotate(
-            "",
-            xy=(x_vu + arrow_len / 2, h + arrow_len),
-            xytext=(x_vu - arrow_len / 2, h + arrow_len),
-            arrowprops=dict(arrowstyle="<->", color="red", lw=2),
-        )
-        ax.text(
-            x_vu,
-            h + arrow_len + 0.02,
-            "Vu",
-            color="red",
-            ha="center",
-            va="bottom",
-            fontsize=9,
-        )
+    ax.add_patch(
+        Polygon(structure_pts, closed=True, facecolor="0.9", edgecolor="black", linewidth=1)
+    )
 
+    # Shear diagram line
+    if beam_type == "volado":
+        ax.plot([0, ln], [h, 0], color="blue", lw=1)
+    else:
         ax.plot([0, ln], [0, h], color="blue", lw=1)
 
-        _dim_vline(ax, 0, h, -support_w - margin * 0.3, "h")
+    # Loads
+    arrow_kwargs = dict(arrowstyle="-|>", color="red", lw=2)
+    if beam_type == "volado":
+        x_vu = d
+        ax.annotate("", xy=(x_vu, h - d), xytext=(x_vu, h), arrowprops=arrow_kwargs)
+        ax.text(x_vu, h + 0.05, "Vu", color="red", ha="center", va="bottom", fontsize=9)
+        _dim_line(ax, 0, x_vu, dim_y1, "d")
+        _dim_vline(ax, h, h - d, x_vu - margin * 0.2, "d")
         _dim_line(ax, 0, ln, dim_y2, f"ln = {ln:.2f} m")
-
         ax.set_xlim(-support_w - margin, ln + margin)
     else:
-        ax.add_patch(
-            Rectangle(
-                (0, y0),
-                ln,
-                h,
-                edgecolor="black",
-                facecolor="0.9",
-                linewidth=1,
-                zorder=1,
-            )
-        )
-        ax.add_patch(
-            Rectangle(
-                (-support_w, y0 - column_h),
-                support_w,
-                column_h,
-                facecolor="0.85",
-                edgecolor="black",
-                hatch="//",
-                linewidth=1,
-                zorder=2,
-            )
-        )
-        ax.add_patch(
-            Rectangle(
-                (ln, y0 - column_h),
-                support_w,
-                column_h,
-                facecolor="0.85",
-                edgecolor="black",
-                hatch="//",
-                linewidth=1,
-                zorder=2,
-            )
-        )
-
-        x_vu_left = d
-        x_vu_right = ln - d
-        for x_vu in (x_vu_left, x_vu_right):
-            ax.annotate(
-                "",
-                xy=(x_vu + arrow_len / 2, h + arrow_len),
-                xytext=(x_vu - arrow_len / 2, h + arrow_len),
-                arrowprops=dict(arrowstyle="<->", color="red", lw=2),
-            )
-            ax.text(
-                x_vu,
-                h + arrow_len + 0.02,
-                "Vu",
-                color="red",
-                ha="center",
-                va="bottom",
-                fontsize=9,
-            )
-
-        # Compression line
-        ax.plot([0, ln], [h, 0], color="blue", lw=1)
-
-
-        # Dimension lines
-        _dim_vline(ax, 0, h, -margin * 0.3, "h")
+        for x_vu in (d, ln - d):
+            ax.annotate("", xy=(x_vu, h - d), xytext=(x_vu, h), arrowprops=arrow_kwargs)
+            ax.text(x_vu, h + 0.05, "Vu", color="red", ha="center", va="bottom", fontsize=9)
+        _dim_line(ax, 0, d, dim_y1, "d")
+        _dim_vline(ax, h, h - d, d - margin * 0.2, "d")
+        _dim_line(ax, 0, ln / 2, dim_y1 - 0.1, "ln/2")
         _dim_line(ax, 0, ln, dim_y2, f"ln = {ln:.2f} m")
-
-        ax.set_xlim(-margin, ln + margin)
+        ax.set_xlim(-margin, ln + margin + support_w)
 
     ax.axis("off")
-    ax.set_ylim(y0 - margin * 0.6, h + margin * 0.6)
+    ax.set_ylim(y0 - column_h - margin * 0.3, h + margin * 0.6)
 
 

--- a/vigapp/pdf_engine/__init__.py
+++ b/vigapp/pdf_engine/__init__.py
@@ -1,3 +1,5 @@
 """PDF report generation utilities."""
 from .latex_renderer import render_report
-__all__ = ["render_report"]
+from .shear_report import generate_shear_pdf
+
+__all__ = ["render_report", "generate_shear_pdf"]

--- a/vigapp/pdf_engine/shear_report.py
+++ b/vigapp/pdf_engine/shear_report.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from reportlab.lib.pagesizes import letter
+from reportlab.lib import colors
+from reportlab.lib.units import cm
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Spacer, Image
+
+
+def generate_shear_pdf(data: Dict[str, Any], result: Any, fig_path: str, output_path: str) -> str:
+    """Generate a simple shear design PDF report."""
+    doc = SimpleDocTemplate(output_path, pagesize=letter)
+    styles = getSampleStyleSheet()
+    flow = [Paragraph("DISE\u00d1O POR CORTE", styles["Heading1"])]
+
+    # Input table
+    table_data = [["Par\u00e1metro", "Valor"]]
+    for k, v in data.items():
+        table_data.append([k, str(v)])
+    tbl = Table(table_data, hAlign="LEFT")
+    tbl.setStyle(TableStyle([
+        ("GRID", (0, 0), (-1, -1), 0.5, colors.black),
+        ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+    ]))
+    flow.extend([tbl, Spacer(1, 0.5 * cm)])
+
+    # Result table
+    res_data = [
+        ["Vc (T)", f"{result.Vc:.2f}"],
+        ["\u03c6Vc (T)", f"{result.phi_Vc:.2f}"],
+        ["\u03c6(Vc+Vs) (T)", f"{result.phi_Vc_Vs:.2f}"],
+        ["Cumple", "SI" if result.ok else "NO"],
+    ]
+    tbl2 = Table(res_data, hAlign="LEFT")
+    tbl2.setStyle(TableStyle([("GRID", (0, 0), (-1, -1), 0.5, colors.black)]))
+    flow.extend([tbl2, Spacer(1, 0.5 * cm)])
+
+    if os.path.isfile(fig_path):
+        flow.append(Image(fig_path, width=14 * cm, height=6 * cm))
+
+    doc.build(flow)
+    return output_path


### PR DESCRIPTION
## Summary
- add DXF export for shear diagrams
- create simple ReportLab PDF exporter for shear design
- expand drawing utilities for shear schemes
- integrate calculation and export buttons in `ShearDesignWindow`
- adjust unit tests for new workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6876e97186c4832bb09e3c800045a6a1