### PR TITLE
Implement shear stirrup distribution

### DIFF
--- a/reporte_cortante_html.py
+++ b/reporte_cortante_html.py
@@ -1,0 +1,55 @@
+import os
+import webbrowser
+from typing import Any, Dict
+
+
+def generar_reporte_cortante_html(datos: Dict[str, Any], result: Any, imagen: str | None = None) -> str:
+    """Generate a simple HTML report for shear design."""
+    os.makedirs("html_report", exist_ok=True)
+
+    img_rel = None
+    if imagen and os.path.isfile(imagen):
+        dst = os.path.join("html_report", os.path.basename(imagen))
+        os.replace(imagen, dst)
+        img_rel = os.path.basename(dst)
+
+    html = [
+        "<!DOCTYPE html>",
+        "<html>",
+        "<head><meta charset='utf-8'><title>Reporte Corte</title>",
+        "<style>body{font-family:Arial;}table{border-collapse:collapse;}td,th{border:1px solid #000;padding:4px;}h1{text-align:left;}</style>",
+        "</head><body>",
+        "<h1>DISEÑO POR CORTE</h1>",
+        "<h2>Datos</h2>",
+        "<table>",
+    ]
+
+    for k, v in datos.items():
+        html.append(f"<tr><td><b>{k}</b></td><td>{v}</td></tr>")
+    html.append("</table>")
+
+    html.extend([
+        "<h2>Resultados</h2>",
+        "<table>",
+        f"<tr><td>Vc (T)</td><td>{result.Vc:.2f}</td></tr>",
+        f"<tr><td>Vs (T)</td><td>{result.Vs:.2f}</td></tr>",
+        f"<tr><td>ϕVc</td><td>{result.phi_Vc:.2f}</td></tr>",
+        f"<tr><td>ϕ(Vc+Vs)</td><td>{result.phi_Vc_Vs:.2f}</td></tr>",
+        f"<tr><td>Separación SC</td><td>{result.S_sc:.2f} cm</td></tr>",
+        f"<tr><td>Separación SR</td><td>{result.S_sr:.2f} cm</td></tr>",
+        f"<tr><td>Cumple</td><td>{'SI' if result.ok else 'NO'}</td></tr>",
+        "</table>",
+    ])
+
+    if img_rel:
+        html.append(f"<img src='{img_rel}' style='width:90%;display:block;margin:auto'>")
+
+    html.append("</body></html>")
+
+    path = os.path.join("html_report", "reporte_cortante.html")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(html))
+
+    webbrowser.open(f"file://{os.path.abspath(path)}")
+    return path
+

--- a/tests/test_shear_design.py
+++ b/tests/test_shear_design.py
@@ -12,6 +12,7 @@ def test_shear_design_sample():
         h=60,
         fc=210,
         phi_long=1.27,
+        beam_type="apoyada",
     )
     assert res.ok
     assert abs(res.S_sc - 12.55) < 0.1
@@ -24,3 +25,20 @@ def test_min_spacing():
     sr = max_spacing_sr(50)
     assert sc <= 15
     assert sr <= 25
+
+
+def test_stirrup_distribution():
+    res = shear_design(
+        Vu=40,
+        Ln=6,
+        d=50,
+        b=30,
+        h=60,
+        fc=210,
+        phi_long=1.27,
+        beam_type="apoyada",
+    )
+    assert res.n_sc > 0
+    assert res.n_sr > 0
+    assert res.sep_sc_real > 0
+    assert res.sep_sr_real > 0

--- a/vigapp/graphics/shear_scheme.py
+++ b/vigapp/graphics/shear_scheme.py
@@ -130,3 +130,39 @@ def draw_shear_scheme(
     ax.set_ylim(y0 - column_h - margin * 0.3, h + margin * 0.6)
 
 
+def draw_stirrup_distribution(
+    ax: plt.Axes,
+    ln: float,
+    result,
+    beam_type: str = "apoyada",
+) -> None:
+    """Draw stirrup positions along the beam span."""
+
+    ax.clear()
+    x = 0.0
+    sc = result.sep_sc_real / 100.0
+    sr = result.sep_sr_real / 100.0
+
+    if beam_type == "volado":
+        for _ in range(result.n_sc):
+            ax.plot([x, x], [0, 1], color="k")
+            x += sc
+        for _ in range(result.n_sr):
+            ax.plot([x, x], [0, 1], color="k")
+            x += sr
+    else:
+        for _ in range(result.n_sc):
+            ax.plot([x, x], [0, 1], color="k")
+            x += sc
+        for _ in range(result.n_sr):
+            ax.plot([x, x], [0, 1], color="k")
+            x += sr
+        for _ in range(result.n_sc):
+            ax.plot([x, x], [0, 1], color="k")
+            x += sc
+
+    ax.set_xlim(0, ln)
+    ax.set_ylim(0, 1)
+    ax.axis("off")
+
+

--- a/vigapp/ui/shear_window.py
+++ b/vigapp/ui/shear_window.py
@@ -129,15 +129,18 @@ class ShearDesignWindow(QMainWindow):
         btn_back = QPushButton("Atr\u00e1s")
         self.btn_calc = QPushButton("Calcular dise\u00f1o por corte")
         self.btn_pdf = QPushButton("Exportar reporte PDF")
+        self.btn_html = QPushButton("Exportar reporte HTML")
         self.btn_dxf = QPushButton("Exportar archivo DXF")
         self.btn_pdf.setEnabled(False)
+        self.btn_html.setEnabled(False)
         self.btn_dxf.setEnabled(False)
 
         layout.addWidget(btn_menu, 11, 0)
         layout.addWidget(btn_back, 11, 1)
         layout.addWidget(self.btn_calc, 12, 0, 1, 2)
         layout.addWidget(self.btn_pdf, 13, 0, 1, 2)
-        layout.addWidget(self.btn_dxf, 14, 0, 1, 2)
+        layout.addWidget(self.btn_html, 14, 0, 1, 2)
+        layout.addWidget(self.btn_dxf, 15, 0, 1, 2)
 
         self.fig, self.ax = plt.subplots(figsize=(5, 3), constrained_layout=True)
         self.canvas = FigureCanvas(self.fig)
@@ -162,6 +165,7 @@ class ShearDesignWindow(QMainWindow):
         self.cb_type.currentIndexChanged.connect(self.draw_diagram)
         self.btn_calc.clicked.connect(self.calculate)
         self.btn_pdf.clicked.connect(self.export_pdf)
+        self.btn_html.clicked.connect(self.export_html)
         self.btn_dxf.clicked.connect(self.export_dxf)
 
         self.update_depth()
@@ -210,10 +214,12 @@ class ShearDesignWindow(QMainWindow):
             fy=fy,
             stirrup_diam=self.cb_estribo.currentText(),
             phi_long=DIAM_CM.get(self.cb_varilla.currentText(), 0),
+            beam_type=self.cb_type.currentText().lower(),
         )
 
         self.draw_diagram()
         self.btn_pdf.setEnabled(True)
+        self.btn_html.setEnabled(True)
         self.btn_dxf.setEnabled(True)
 
     # ------------------------------------------------------------------
@@ -233,6 +239,24 @@ class ShearDesignWindow(QMainWindow):
             "fy": self.ed_fy.text(),
         }
         generate_shear_pdf(data, self.result, fig_path, "reporte_cortante.pdf")
+
+    # ------------------------------------------------------------------
+    def export_html(self):
+        from ..reporte_cortante_html import generar_reporte_cortante_html
+        if not hasattr(self, "result"):
+            return
+        fig_path = "shear_plot.png"
+        self.fig.savefig(fig_path, dpi=150)
+        data = {
+            "Vu": self.ed_vu.text(),
+            "Ln": self.ed_ln.text(),
+            "d": self.ed_d.text(),
+            "b": self.ed_b.text(),
+            "h": self.ed_h.text(),
+            "f'c": self.ed_fc.text(),
+            "fy": self.ed_fy.text(),
+        }
+        generar_reporte_cortante_html(data, self.result, fig_path)
 
     # ------------------------------------------------------------------
     def export_dxf(self):


### PR DESCRIPTION
## Summary
- calculate stirrup distribution and real spacing
- add stirrup layout drawing helper
- export shear design results as HTML
- expose new UI button and wire exports
- extend tests for distribution details

## Testing
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6877abc2f990832b8364c35b0ee74c3e