### PR TITLE
Fix contact text typo

### DIFF
--- a/vigapp/activation_dialog.py
+++ b/vigapp/activation_dialog.py
@@ -87,7 +87,7 @@ class ActivationDialog(QDialog):
             self,
             "Contacto",
             (
-                "COMUNICARSE AL SIGUIENTE CORREO PARA SOLICTAR LA CLAVE DE "
+                "COMUNICARSE AL SIGUIENTE CORREO PARA SOLICITAR LA CLAVE DE "
                 "ACTIVACION: abelcorderotineo99@gmail.com  cel y wsp : 922148420"
             ),
         )

--- a/vigapp/ui/menu_window.py
+++ b/vigapp/ui/menu_window.py
@@ -364,7 +364,7 @@ class MenuWindow(QMainWindow):
             self,
             "Contacto",
             (
-                "COMUNICARSE AL SIGUIENTE CORREO PARA SOLICTAR LA CLAVE DE "
+                "COMUNICARSE AL SIGUIENTE CORREO PARA SOLICITAR LA CLAVE DE "
                 "ACTIVACION: abelcorderotineo99@gmail.com  cel y wsp : 922148420"
             ),
         )


### PR DESCRIPTION
## Summary
- fix a typo in `show_contact` message
- fix the same typo in activation dialog

## Testing
- `pytest tests/test_moment_app.py -q`
- `pytest tests/test_design_window.py -q`
- `pytest tests/test_shear_window.py -q` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6886cb169d3c83248419f49870359032