### PR TITLE
Add cantilever shear design test and PyQt fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+@pytest.fixture(scope="session")
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    yield app
+    app.quit()

--- a/tests/test_design_window.py
+++ b/tests/test_design_window.py
@@ -11,13 +11,12 @@ def test_calc_as_req_sample():
     assert abs(result - 13.2991) < 1e-4
 
 
-def test_required_areas_offscreen(monkeypatch):
+def test_required_areas_offscreen(qapp, monkeypatch):
     """Ensure required areas use the general formula with limits."""
     monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
-    from PyQt5.QtWidgets import QApplication
     import numpy as np
 
-    app = QApplication([])
+    app = qapp
     mn = np.array([-10.0, -15.0, -20.0])
     mp = np.array([5.0, 10.0, 15.0])
     win = DesignWindow(mn, mp, show_window=False)
@@ -35,6 +34,4 @@ def test_required_areas_offscreen(monkeypatch):
     assert np.all(as_n <= win.as_max)
     assert np.all(as_p >= win.as_min)
     assert np.all(as_p <= win.as_max)
-
-    app.quit()
 

--- a/tests/test_shear_design.py
+++ b/tests/test_shear_design.py
@@ -42,3 +42,23 @@ def test_stirrup_distribution():
     assert res.n_sr > 0
     assert res.sep_sc_real > 0
     assert res.sep_sr_real > 0
+
+def test_cantilever_design():
+    """Shear design for a cantilever beam returns positive spacing."""
+    Ln = 6
+    res = shear_design(
+        Vu=25,
+        Ln=Ln,
+        d=45,
+        b=30,
+        h=60,
+        fc=210,
+        phi_long=1.27,
+        beam_type="volado",
+    )
+    assert res.ok
+    assert abs(res.Lc - (Ln - res.Lo)) < 1e-6
+    assert res.n_sc > 0
+    assert res.n_sr > 0
+    assert res.sep_sc_real > 0
+    assert res.sep_sr_real > 0

--- a/tests/test_shear_window.py
+++ b/tests/test_shear_window.py
@@ -7,9 +7,9 @@ from vigapp.ui.shear_window import ShearDesignWindow
 import numpy as np
 
 
-def test_shear_diagram_offscreen(monkeypatch):
+def test_shear_diagram_offscreen(qapp, monkeypatch):
     monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
-    app = QApplication([])
+    app = qapp
     mn = np.array([-10.0, -15.0, -20.0])
     mp = np.array([5.0, 10.0, 15.0])
     design = DesignWindow(mn, mp, show_window=False)
@@ -26,12 +26,10 @@ def test_shear_diagram_offscreen(monkeypatch):
     shear2.ed_ln.setText("6")
     shear2.calculate()
     assert shear2.ed_d.isReadOnly()
-    app.quit()
 
 
-def test_section_canvas_exists(monkeypatch):
+def test_section_canvas_exists(qapp, monkeypatch):
     monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
-    app = QApplication([])
+    app = qapp
     shear = ShearDesignWindow(None, show_window=False)
     assert hasattr(shear, "canvas_sec")
-    app.quit()

--- a/vigapp/models/shear_design.py
+++ b/vigapp/models/shear_design.py
@@ -106,18 +106,16 @@ def shear_design(
         Lo_cm = 2.0 * h
     else:
         Lo_cm = 2.0 * d
-    Ln_cm = Ln * 100.0
-    if Ln_cm < 0:
-        Ln_cm = 0.0
 
-    if Ln_cm - (2.0 * Lo_cm) < 0:
-        Lc_cm = 0.0
+    Ln_cm = max(Ln * 100.0, 0.0)
+
+    if beam_type.lower() == "volado":
+        Lc_cm = Ln_cm - Lo_cm
     else:
-        Lc_cm = Ln_cm - (2.0 * Lo_cm)
+        Lc_cm = max(Ln_cm - (2.0 * Lo_cm), 0.0)
 
     # Number of stirrups by zone and real spacing (cm)
-    if system.lower() == "volado":
-        Lc_cm = Ln_cm - Lo_cm
+    if beam_type.lower() == "volado":
         n_sc = ceil(Lo_cm / S_sc) if S_sc > 0 else 0
         sep_sc = Lo_cm / n_sc if n_sc else 0.0
         n_sr = ceil(Lc_cm / S_sr) if S_sr > 0 else 0


### PR DESCRIPTION
## Summary
- fix shear design logic for cantilever beams
- manage QApplication via test fixture
- update UI tests to reuse a single QApplication
- add new test for volado beams

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886cb2c0f308324b83075f0c065de03