### PR TITLE
Improve shear result view

### DIFF
--- a/vigapp/graphics/shear_scheme.py
+++ b/vigapp/graphics/shear_scheme.py
@@ -133,36 +133,100 @@ def draw_shear_scheme(
 def draw_stirrup_distribution(
     ax: plt.Axes,
     ln: float,
+    h: float,
     result,
     beam_type: str = "apoyada",
 ) -> None:
-    """Draw stirrup positions along the beam span."""
+    """Draw stirrup positions along a shaded beam."""
 
     ax.clear()
-    x = 0.0
+
+    column_h = h + 0.2
+    column_w = 0.2
+    y0 = 0.0
+
+    if beam_type == "volado":
+        structure_pts = [
+            (-column_w, y0 - column_h),
+            (0, y0 - column_h),
+            (0, y0),
+            (ln, y0),
+            (ln, y0 + h),
+            (0, y0 + h),
+            (-column_w, y0 + h),
+        ]
+    else:
+        structure_pts = [
+            (-column_w, y0 - column_h),
+            (0, y0 - column_h),
+            (0, y0),
+            (ln, y0),
+            (ln, y0 - column_h),
+            (ln + column_w, y0 - column_h),
+            (ln + column_w, y0 + h),
+            (ln, y0 + h),
+            (0, y0 + h),
+            (-column_w, y0 + h),
+        ]
+
+    ax.add_patch(
+        Polygon(structure_pts, closed=True, facecolor="0.9", edgecolor="black", lw=1)
+    )
+
     sc = result.sep_sc_real / 100.0
     sr = result.sep_sr_real / 100.0
 
-    if beam_type == "volado":
+    # Left side
+    x = sc
+    for _ in range(result.n_sc):
+        if x >= ln:
+            break
+        ax.plot([x, x], [0, h], color="k")
+        x += sc
+
+    for _ in range(result.n_sr):
+        if x >= ln:
+            break
+        ax.plot([x, x], [0, h], color="k")
+        x += sr
+
+    if beam_type != "volado":
+        x = ln - sc * result.n_sc
         for _ in range(result.n_sc):
-            ax.plot([x, x], [0, 1], color="k")
-            x += sc
-        for _ in range(result.n_sr):
-            ax.plot([x, x], [0, 1], color="k")
-            x += sr
-    else:
-        for _ in range(result.n_sc):
-            ax.plot([x, x], [0, 1], color="k")
-            x += sc
-        for _ in range(result.n_sr):
-            ax.plot([x, x], [0, 1], color="k")
-            x += sr
-        for _ in range(result.n_sc):
-            ax.plot([x, x], [0, 1], color="k")
+            if x >= ln:
+                break
+            ax.plot([x, x], [0, h], color="k")
             x += sc
 
-    ax.set_xlim(0, ln)
-    ax.set_ylim(0, 1)
+    dim_y = y0 - 0.15 * h
+    if beam_type == "volado":
+        _dim_line(ax, 0, result.Lo, dim_y, f"Lo = {result.Lo:.2f} m")
+        _dim_line(
+            ax,
+            result.Lo,
+            result.Lo + result.Lc,
+            dim_y,
+            f"Lc = {result.Lc:.2f} m",
+        )
+    else:
+        _dim_line(ax, 0, result.Lo, dim_y, f"Lo = {result.Lo:.2f} m")
+        _dim_line(
+            ax,
+            result.Lo,
+            result.Lo + result.Lc,
+            dim_y,
+            f"Lc = {result.Lc:.2f} m",
+        )
+        _dim_line(
+            ax,
+            result.Lo + result.Lc,
+            ln,
+            dim_y,
+            f"Lo = {result.Lo:.2f} m",
+        )
+
+    ax.set_xlim(-column_w, ln + column_w)
+    ax.set_ylim(y0 - column_h - 0.1 * h, y0 + h + 0.1 * h)
     ax.axis("off")
 
 

--- a/vigapp/ui/shear_result_window.py
+++ b/vigapp/ui/shear_result_window.py
@@ -9,11 +9,12 @@ from ..graphics.shear_scheme import draw_stirrup_distribution
 class ShearResultWindow(QMainWindow):
     """Window that displays stirrup distribution and a summary."""
 
-    def __init__(self, result, ln, *, Vu=0.0, beam_type="apoyada", parent=None, show_window=True):
+    def __init__(self, result, ln, *, Vu=0.0, beam_type="apoyada", h=0.0, parent=None, show_window=True):
         super().__init__(parent)
         self.result = result
         self.ln = ln
         self.Vu = Vu
+        self.h = h
         self.beam_type = beam_type
         self.setWindowTitle("Resultados Cortante")
         self._build_ui()
@@ -25,7 +26,7 @@ class ShearResultWindow(QMainWindow):
         self.setCentralWidget(central)
         layout = QVBoxLayout(central)
 
-        self.fig, self.ax = plt.subplots(figsize=(6, 3))
+        self.fig, self.ax = plt.subplots(figsize=(8, 3))
         self.canvas = FigureCanvas(self.fig)
         layout.addWidget(self.canvas)
 
@@ -40,7 +41,9 @@ class ShearResultWindow(QMainWindow):
         self.lbl_summary.setAlignment(Qt.AlignTop)
         layout.addWidget(self.lbl_summary)
 
-        draw_stirrup_distribution(self.ax, self.ln, self.result, self.beam_type)
+        draw_stirrup_distribution(self.ax, self.ln, self.h, self.result, self.beam_type)
         self.ax.set_title("Distribuci\u00f3n de estribos")
         self.canvas.draw()
+
+        self.resize(900, 400)
 

--- a/vigapp/ui/shear_window.py
+++ b/vigapp/ui/shear_window.py
@@ -230,6 +230,7 @@ class ShearDesignWindow(QMainWindow):
             Ln,
             Vu=Vu,
             beam_type=self.cb_type.currentText().lower(),
+            h=float(self.ed_h.text()) / 100.0,
             show_window=True,
         )
 


### PR DESCRIPTION
## Summary
- improve stirrup distribution drawing
- enlarge result window and show beam geometry
- pass beam height when creating the result window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886d53ca0a08324b557c81d601d6770