### PR TITLE
feat: add 5cm stirrup offset

### DIFF
--- a/tests/test_shear_design.py
+++ b/tests/test_shear_design.py
@@ -63,3 +63,33 @@ def test_cantilever_design():
     assert res.n_sr > 0
     assert res.sep_sc_real > 0
     assert res.sep_sr_real > 0
+
+
+def test_first_stirrup_offset_supported():
+    res = shear_design(
+        Vu=35,
+        Ln=5,
+        d=45,
+        b=30,
+        h=55,
+        fc=210,
+        phi_long=1.27,
+        beam_type="apoyada",
+    )
+    offset = res.Lo * 100 - res.n_sc * res.sep_sc_real
+    assert abs(offset - 5) < 1e-6
+
+
+def test_first_stirrup_offset_cantilever():
+    res = shear_design(
+        Vu=25,
+        Ln=5,
+        d=40,
+        b=30,
+        h=50,
+        fc=210,
+        phi_long=1.27,
+        beam_type="volado",
+    )
+    offset = res.Lo * 100 - res.n_sc * res.sep_sc_real
+    assert abs(offset - 5) < 1e-6

--- a/vigapp/graphics/shear_scheme.py
+++ b/vigapp/graphics/shear_scheme.py
@@ -165,15 +165,17 @@ def draw_stirrup_distribution(
 
     sc = result.sep_sc_real / 100.0
     sr = result.sep_sr_real / 100.0
+    offset = 0.05
 
     # Left side
-    x = sc
+    x = offset
     for _ in range(result.n_sc):
         if x >= ln:
             break
         ax.plot([x, x], [0, h], color="k")
         x += sc
 
+    x = result.Lo + sr
     for _ in range(result.n_sr):
         if x >= ln:
             break
@@ -181,7 +183,7 @@ def draw_stirrup_distribution(
         x += sr
 
     if beam_type != "volado":
-        x = ln - sc * result.n_sc
+        x = ln - offset - sc * (result.n_sc - 1)
         for _ in range(result.n_sc):
             if x >= ln:
                 break
@@ -190,9 +192,9 @@ def draw_stirrup_distribution(
     # Spacing dimensions
     dim_y_sep = y0 - 0.05 * h
     if result.n_sc > 0:
-        _dim_line(ax, 0, sc, dim_y_sep, f"S_sc \u2248 {result.S_sc:.0f} cm")
+        _dim_line(ax, offset, offset + sc, dim_y_sep, f"S_sc \u2248 {result.S_sc:.0f} cm")
         if beam_type != "volado":
-            _dim_line(ax, ln - sc, ln, dim_y_sep, f"S_sc \u2248 {result.S_sc:.0f} cm")
+            _dim_line(ax, ln - offset - sc, ln - offset, dim_y_sep, f"S_sc \u2248 {result.S_sc:.0f} cm")
     if result.n_sr > 0:
         _dim_line(ax, result.Lo, result.Lo + sr, dim_y_sep, f"S_sr \u2248 {result.S_sr:.0f} cm")
 

--- a/vigapp/models/shear_design.py
+++ b/vigapp/models/shear_design.py
@@ -119,16 +119,13 @@ def shear_design(
         Lc_cm = max(Ln_cm - (2.0 * Lo_cm), 0.0)
 
     # Number of stirrups by zone and real spacing (cm)
-    if beam_type.lower() == "volado":
-        n_sc = ceil(Lo_cm / S_sc) if S_sc > 0 else 0
-        sep_sc = Lo_cm / n_sc if n_sc else 0.0
-        n_sr = ceil(Lc_cm / S_sr) if S_sr > 0 else 0
-        sep_sr = Lc_cm / n_sr if n_sr else 0.0
-    else:
-        n_sc = ceil(Lo_cm / S_sc) if S_sc > 0 else 0
-        sep_sc = Lo_cm / n_sc if n_sc else 0.0
-        n_sr = ceil(Lc_cm / S_sr) if S_sr > 0 else 0
-        sep_sr = Lc_cm / n_sr if n_sr else 0.0
+    offset_cm = 5.0  # first stirrup 5 cm from column face
+    sc_len = max(Lo_cm - offset_cm, 0.0)
+    n_sc = ceil(sc_len / S_sc) if S_sc > 0 else 0
+    sep_sc = sc_len / n_sc if n_sc else 0.0
+
+    n_sr = ceil(Lc_cm / S_sr) if S_sr > 0 else 0
+    sep_sr = Lc_cm / n_sr if n_sr else 0.0
 
     Lo = Lo_cm / 100.0
     Lc = Lc_cm / 100.0


### PR DESCRIPTION
## Summary
- ensure first shear stirrup starts 5cm from support
- show 5cm offset in stirrup distribution diagrams
- test stirrup offset for supported and cantilever beams

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689297a71ecc83249f05d20d7d9446a4