### PR TITLE
Add CI workflow and document results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      QT_QPA_PLATFORM: offscreen
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Ejecuta las pruebas con:
 pytest
 ```
 
+## Integración continua
+
+Cada push o *pull request* activa un flujo de GitHub Actions que instala las dependencias (`pip install -r requirements.txt`) y ejecuta `pytest` con la variable `QT_QPA_PLATFORM=offscreen`.
+
+En la pestaña **Actions** se puede consultar el historial de ejecuciones. Un ✔️ verde indica que todas las pruebas pasaron; un ❌ rojo significa que alguna falló. Haz clic en **Details** para revisar los registros y corregir errores.
+
 ## Licencia
 
 Este proyecto se distribuye bajo los t\u00e9rminos de la [Licencia MIT](LICENSE).


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow to install dependencies and run pytest headlessly
- document how to interpret CI results in README

## Testing
- `QT_QPA_PLATFORM=offscreen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895327395e8832496d15ed062efa511