### PR TITLE
Use Jinja2 templates for flexion report

### DIFF
--- a/reporte_flexion_html.py
+++ b/reporte_flexion_html.py
@@ -3,6 +3,8 @@ import subprocess
 import webbrowser
 from typing import Any, Dict, List
 
+from jinja2 import Environment, FileSystemLoader
+
 
 def generar_reporte_html(
     datos: Dict[str, Any],
@@ -12,7 +14,7 @@ def generar_reporte_html(
     seccion: str | None = None,
     calc_sections: List[Any] | None = None,
 ) -> None:
-    """Genera un reporte HTML profesional usando MathJax y lo abre en el navegador."""
+    """Genera un reporte HTML profesional usando una plantilla Jinja2."""
     os.makedirs("html_report", exist_ok=True)
     import shutil
 
@@ -41,49 +43,10 @@ def generar_reporte_html(
     h = datos.get("h") or datos.get("h (cm)")
     titulo = f"DISE\u00d1O A FLEXI\u00d3N DE VIGA {_fmt(b)}x{_fmt(h)}"
 
-    html = [
-        "<!DOCTYPE html>",
-        "<html>",
-        "<head>",
-        "<meta charset='utf-8'>",
-        "<title>Reporte</title>",
-        "<script src='https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'></script>",
-        "<style>",
-        "body {\n  font-family: Arial, sans-serif;\n  background: #f0f0f0;\n  margin: 0;\n  padding: 0;\n}",
-        ".page {\n  width: 21cm;\n  min-height: 29.7cm;\n  padding: 2.5cm 3cm;\n  margin: 1cm auto;\n  background: white;\n  box-shadow: 0 0 5px rgba(0,0,0,0.1);\n}",
-        "h1, h2, h3 { text-align: left; margin-top: 1.5em; }",
-        ".norma { font-size: 0.8em; color: #555; }",
-        "table { border-collapse: collapse; width: 280px; margin-bottom: 1em; }",
-        "td, th { border: 1px solid #000; padding: 5px 8px; }",
-        ".formula, .reemplazo, .resultado { margin-left: 20px; font-size: 15px; }",
-        ".imagen-centro { display: block; margin: 20px auto; max-width: 100%; }",
-        "@media print { button { display: none; } body { background: white; } }",
-        "</style>",
-        "<script>function toggleEdit(btn,id){var e=document.getElementById(id);if(!e)return;var ed=e.getAttribute('contenteditable')==='true';e.setAttribute('contenteditable', ed?'false':'true');btn.textContent=ed?'Editar':'Listo';}",
-        "function exportWord(){var html=document.documentElement.outerHTML;var blob=new Blob(['\ufeff',html],{type:'application/msword'});var url=URL.createObjectURL(blob);var a=document.createElement('a');a.href=url;a.download='reporte.doc';a.click();URL.revokeObjectURL(url);}</script>",
-        "</head>",
-        "<body>",
-        "<div style='position:fixed; top:20px; right:20px;'><button onclick=\"window.print()\">Exportar a PDF</button> <button onclick=\"exportWord()\">Exportar a Word</button></div>",
-        "<div class='page'>",
-        f"<h1 contenteditable='true'>{titulo}</h1>",
-        "<div style='display:flex; align-items:stretch; gap:20px; height:auto; min-height:270px;'>",
-        "<div style='flex:1; display:flex; align-items:center;'>",
-        "<table style='margin: 0;'>",
-    ]
-
+    datos_items = []
     for k, v in datos.items():
         label = "h" if k in ("h (cm)", "Altura (h)", "Alto", "ALTO") else k
-        html.append(f"<tr><td><b>{label}</b></td><td>{_fmt(v)}</td></tr>")
-    html.extend(
-        [
-            "</table>",
-            "</div>",
-            "<div style='flex:1; text-align:center; display:flex; align-items:center; justify-content:center;'>",
-            f'<img src="{section_rel or "img_seccion_viga.png"}" style="height:350px; width:auto; object-fit:contain; display:block; margin:auto;" alt="Sección">',
-            "</div>",
-            "</div>",
-        ]
-    )
+        datos_items.append({"label": label, "value": _fmt(v)})
 
     orden = [
         ("Calculo de Peralte <span class='norma'>(E060 Art. 17.5.2)</span>", "peralte"),
@@ -94,7 +57,7 @@ def generar_reporte_html(
         ("Calculo de As m\u00e1x <span class='norma'>(E060 Art. 10.3.4)</span>", "as_max"),
     ]
 
-    html.append("<h2>C\u00c1LCULOS</h2>")
+    blocks: List[Dict[str, Any]] = []
     sec_id = 0
     for subt, key in orden:
         info = resultados.get(key, {})
@@ -104,76 +67,58 @@ def generar_reporte_html(
         if not (gen or rep or res):
             continue
         sec_id += 1
-        hid = f"h{sec_id}"
-        html.append(
-            f"<h3 id='{hid}' contenteditable='false'>{subt} <button onclick=\"toggleEdit(this,'{hid}')\">Editar</button></h3>"
-        )
+        block: Dict[str, Any] = {"hid": f"h{sec_id}", "subt": subt}
         if gen:
-            fid = f"f{sec_id}"
-            html.append(
-                f"<div id='{fid}' class='formula' contenteditable='false'>$$ {gen} $$ <button onclick=\"toggleEdit(this,'{fid}')\">Editar</button></div>"
-            )
+            block["fid"] = f"f{sec_id}"
+            block["gen"] = gen
         if rep:
-            rid = f"r{sec_id}"
-            html.append(
-                f"<div id='{rid}' class='reemplazo' contenteditable='false'>$$ {rep} $$ <button onclick=\"toggleEdit(this,'{rid}')\">Editar</button></div>"
-            )
+            block["rid"] = f"r{sec_id}"
+            block["rep"] = rep
         if res:
-            sid = f"s{sec_id}"
-            html.append(
-                f"<div id='{sid}' class='resultado' contenteditable='false'>$$ {res} $$ <button onclick=\"toggleEdit(this,'{sid}')\">Editar</button></div>"
-            )
+            block["sid"] = f"s{sec_id}"
+            block["res"] = res
+        blocks.append(block)
 
+    calc_blocks: List[Dict[str, Any]] = []
     if calc_sections:
-        html.append("<h2>CALCULO DE AS REQUERIDO</h2>")
         for tit, formulas in calc_sections:
             sec_id += 1
-            hid = f"h{sec_id}"
-            html.append(
-                f"<h3 id='{hid}' contenteditable='false'>{tit} <button onclick=\"toggleEdit(this,'{hid}')\">Editar</button></h3>"
-            )
-            for frm in formulas:
-                sid = f"x{sec_id}_{formulas.index(frm)}"
-                html.append(
-                    f"<div id='{sid}' class='formula' contenteditable='false'>$$ {frm} $$ <button onclick=\"toggleEdit(this,'{sid}')\">Editar</button></div>"
-                )
+            cblock = {"hid": f"h{sec_id}", "title": tit, "formulas": []}
+            for idx, frm in enumerate(formulas):
+                cblock["formulas"].append({"id": f"x{sec_id}_{idx}", "expr": frm})
+            calc_blocks.append(cblock)
 
-    if tabla or img_views:
-        html.append("</div><div class='page'>")
-
+    tabla_rows: List[Dict[str, str]] = []
     if tabla:
-        html.append("<h2>RESUMEN DE ACERO</h2>")
-        html.append("<table>")
-        html.append(
-            "<tr><th>Secci\u00f3n</th><th>AS REQUERIDO</th><th>AS DISE\u00d1O</th><th>Estado</th></tr>"
-        )
-        as_min = float(resultados.get("as_min", {}).get("valor", 0))  # Asegúrate de tenerlo definido
-
+        as_min = float(resultados.get("as_min", {}).get("valor", 0))
         for sec, req, dis, est in tabla:
             try:
                 req_val = float(req)
             except (ValueError, TypeError):
                 req_val = 0
-
-            # Si As requerido es menor que As mínimo, usar As mínimo
             req_mostrar = max(req_val, as_min)
-            req_fmt = f"{req_mostrar:.2f}"
-
-            html.append(
-                f"<tr><td>{sec}</td><td>{req_fmt}</td><td>{dis}</td><td>{est}</td></tr>"
+            tabla_rows.append(
+                {"sec": sec, "req": f"{req_mostrar:.2f}", "dis": dis, "est": est}
             )
-        
-        html.append("</table>")
 
-    for img in img_views:
-        html.append(f"<img src='{img}' class='imagen-centro' alt='Corte'>")
+    context = {
+        "titulo": titulo,
+        "datos": datos_items,
+        "section_rel": section_rel,
+        "blocks": blocks,
+        "calc_sections": calc_blocks,
+        "tabla": tabla_rows,
+        "img_views": img_views,
+    }
 
-    html.append("</div>")
-    html.append("</body></html>")
+    template_dir = os.path.join(os.path.dirname(__file__), "vigapp", "html_templates")
+    env = Environment(loader=FileSystemLoader(template_dir), autoescape=True)
+    template = env.get_template("reporte_flexion.html.j2")
+    html_content = template.render(context)
 
     path = os.path.join("html_report", "reporte_flexion.html")
     with open(path, "w", encoding="utf-8") as fh:
-        fh.write("\n".join(html))
+        fh.write(html_content)
 
     abs_path = os.path.abspath(path)
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,16 @@
 import os
 import pytest
-from PyQt5.QtWidgets import QApplication
+
+try:
+    from PyQt5.QtWidgets import QApplication
+except Exception:  # pragma: no cover - handled in test environment
+    QApplication = None
+
 
 @pytest.fixture(scope="session")
 def qapp():
+    if QApplication is None:
+        pytest.skip("PyQt5 not available")
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     app = QApplication.instance() or QApplication([])
     yield app

--- a/tests/test_reporte_flexion_html.py
+++ b/tests/test_reporte_flexion_html.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from reporte_flexion_html import generar_reporte_html
+
+
+def test_generar_reporte_html_renders_data(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: None)
+    monkeypatch.setattr("webbrowser.open", lambda *args, **kwargs: None)
+
+    datos = {"b": 30, "h": 50}
+    resultados = {"peralte": {"general": "d=b-h", "resultado": "d=20"}}
+
+    generar_reporte_html(datos, resultados)
+
+    path = Path("html_report") / "reporte_flexion.html"
+    assert path.exists()
+    content = path.read_text(encoding="utf-8")
+    assert "DISEÑO A FLEXIÓN DE VIGA 30x50" in content
+    assert "d=b-h" in content
+    assert "d=20" in content

--- a/vigapp/html_templates/reporte_flexion.html.j2
+++ b/vigapp/html_templates/reporte_flexion.html.j2
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8'>
+<title>Reporte</title>
+<script src='https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'></script>
+<style>
+body {
+  font-family: Arial, sans-serif;
+  background: #f0f0f0;
+  margin: 0;
+  padding: 0;
+}
+.page {
+  width: 21cm;
+  min-height: 29.7cm;
+  padding: 2.5cm 3cm;
+  margin: 1cm auto;
+  background: white;
+  box-shadow: 0 0 5px rgba(0,0,0,0.1);
+}
+h1, h2, h3 { text-align: left; margin-top: 1.5em; }
+.norma { font-size: 0.8em; color: #555; }
+table { border-collapse: collapse; width: 280px; margin-bottom: 1em; }
+td, th { border: 1px solid #000; padding: 5px 8px; }
+.formula, .reemplazo, .resultado { margin-left: 20px; font-size: 15px; }
+.imagen-centro { display: block; margin: 20px auto; max-width: 100%; }
+@media print { button { display: none; } body { background: white; } }
+</style>
+<script>
+function toggleEdit(btn,id){
+  var e=document.getElementById(id);
+  if(!e)return;
+  var ed=e.getAttribute('contenteditable')==='true';
+  e.setAttribute('contenteditable', ed?'false':'true');
+  btn.textContent=ed?'Editar':'Listo';
+}
+function exportWord(){
+  var html=document.documentElement.outerHTML;
+  var blob=new Blob(['\ufeff',html],{type:'application/msword'});
+  var url=URL.createObjectURL(blob);
+  var a=document.createElement('a');
+  a.href=url;
+  a.download='reporte.doc';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+</script>
+</head>
+<body>
+<div style='position:fixed; top:20px; right:20px;'><button onclick="window.print()">Exportar a PDF</button> <button onclick="exportWord()">Exportar a Word</button></div>
+<div class='page'>
+<h1 contenteditable='true'>{{ titulo }}</h1>
+<div style='display:flex; align-items:stretch; gap:20px; height:auto; min-height:270px;'>
+<div style='flex:1; display:flex; align-items:center;'>
+<table style='margin: 0;'>
+{% for item in datos %}
+<tr><td><b>{{ item.label }}</b></td><td>{{ item.value }}</td></tr>
+{% endfor %}
+</table>
+</div>
+<div style='flex:1; text-align:center; display:flex; align-items:center; justify-content:center;'>
+<img src="{{ section_rel or 'img_seccion_viga.png' }}" style="height:350px; width:auto; object-fit:contain; display:block; margin:auto;" alt="Sección">
+</div>
+</div>
+
+<h2>CÁLCULOS</h2>
+{% for block in blocks %}
+<h3 id="{{ block.hid }}" contenteditable='false'>{{ block.subt }} <button onclick="toggleEdit(this,'{{ block.hid }}')">Editar</button></h3>
+{% if block.gen %}
+<div id="{{ block.fid }}" class='formula' contenteditable='false'>$$ {{ block.gen }} $$ <button onclick="toggleEdit(this,'{{ block.fid }}')">Editar</button></div>
+{% endif %}
+{% if block.rep %}
+<div id="{{ block.rid }}" class='reemplazo' contenteditable='false'>$$ {{ block.rep }} $$ <button onclick="toggleEdit(this,'{{ block.rid }}')">Editar</button></div>
+{% endif %}
+{% if block.res %}
+<div id="{{ block.sid }}" class='resultado' contenteditable='false'>$$ {{ block.res }} $$ <button onclick="toggleEdit(this,'{{ block.sid }}')">Editar</button></div>
+{% endif %}
+{% endfor %}
+
+{% if calc_sections %}
+<h2>CALCULO DE AS REQUERIDO</h2>
+{% for cs in calc_sections %}
+<h3 id="{{ cs.hid }}" contenteditable='false'>{{ cs.title }} <button onclick="toggleEdit(this,'{{ cs.hid }}')">Editar</button></h3>
+{% for frm in cs.formulas %}
+<div id="{{ frm.id }}" class='formula' contenteditable='false'>$$ {{ frm.expr }} $$ <button onclick="toggleEdit(this,'{{ frm.id }}')">Editar</button></div>
+{% endfor %}
+{% endfor %}
+{% endif %}
+
+{% if tabla or img_views %}
+</div><div class='page'>
+{% endif %}
+
+{% if tabla %}
+<h2>RESUMEN DE ACERO</h2>
+<table>
+<tr><th>Sección</th><th>AS REQUERIDO</th><th>AS DISEÑO</th><th>Estado</th></tr>
+{% for row in tabla %}
+<tr><td>{{ row.sec }}</td><td>{{ row.req }}</td><td>{{ row.dis }}</td><td>{{ row.est }}</td></tr>
+{% endfor %}
+</table>
+{% endif %}
+
+{% for img in img_views %}
+<img src='{{ img }}' class='imagen-centro' alt='Corte'>
+{% endfor %}
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- render flexion report through Jinja2 template
- store HTML template under vigapp/html_templates
- add regression test for HTML rendering and skip PyQt5-dependent tests when unavailable

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*
- `pytest tests/test_reporte_flexion_html.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895327471988324b1d980c1e2971709