### PR TITLE
Centralizar PYTHONPATH en pruebas y actualizar documentación

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ Puedes instalar todas las dependencias de desarrollo con:
 pip install -r requirements-dev.txt
 ```
 
+`tests/conftest.py` ajusta automáticamente `PYTHONPATH` para que el paquete `vigapp` pueda importarse durante las pruebas, por lo que no es necesario modificar `sys.path` en los archivos de test.
+
 En entornos sin interfaz gráfica (por ejemplo, servidores de integración continua) establece `QT_QPA_PLATFORM=offscreen` para que Qt no requiera pantalla:
 
 ```bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 import os
+import sys
 import pytest
 from PyQt5.QtWidgets import QApplication
+
+# Ensure the project root is on PYTHONPATH so tests can import vigapp
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+os.environ.setdefault("PYTHONPATH", ROOT_DIR)
 
 @pytest.fixture(scope="session")
 def qapp():

--- a/tests/test_design_window.py
+++ b/tests/test_design_window.py
@@ -1,7 +1,3 @@
-import os
-import sys
-
-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from vigapp.ui.design_window import DesignWindow
 from vigapp.ui.design import calc_as_req
 

--- a/tests/test_moment_app.py
+++ b/tests/test_moment_app.py
@@ -1,8 +1,4 @@
-import os
-import sys
 import numpy as np
-
-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from vigapp.ui.moment_app import MomentApp
 
 

--- a/tests/test_shear_design.py
+++ b/tests/test_shear_design.py
@@ -1,5 +1,3 @@
-import os, sys
-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from vigapp.models.shear_design import shear_design, min_spacing_sc, max_spacing_sr
 
 

--- a/tests/test_shear_window.py
+++ b/tests/test_shear_window.py
@@ -1,10 +1,6 @@
-import os
-import sys
-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-from PyQt5.QtWidgets import QApplication
+import numpy as np
 from vigapp.ui.design_window import DesignWindow
 from vigapp.ui.shear_window import ShearDesignWindow
-import numpy as np
 
 
 def test_shear_diagram_offscreen(qapp, monkeypatch):


### PR DESCRIPTION
## Summary
- Añadir configuración de PYTHONPATH en `tests/conftest.py` para importar `vigapp`
- Eliminar hacks de `sys.path.append` en los módulos de pruebas
- Documentar el nuevo flujo de ejecución de tests en `CONTRIBUTING.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68953275650c8324b02144eee5a427b0