### PR TITLE
Implement JSON project save and load utilities

### DIFF
--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -1,0 +1,19 @@
+"""Tests for the :mod:`vigapp.sistema.project_manager` module."""
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from vigapp.sistema.project_manager import ProjectManager
+
+
+def test_save_and_load_roundtrip(tmp_path):
+    manager = ProjectManager()
+    model = {"name": "sample", "values": [1, 2, 3]}
+    file_path = tmp_path / "project.json"
+
+    manager.save(model, file_path)
+    loaded = manager.load(file_path)
+
+    assert loaded == model
+

--- a/vigapp/sistema/project_manager.py
+++ b/vigapp/sistema/project_manager.py
@@ -5,8 +5,35 @@ class ProjectManager:
     """Handles serialization of beam configurations."""
 
     def save(self, model, path):
-        """Save the model to disk."""
+        """Save the model to disk.
+
+        Parameters
+        ----------
+        model : dict
+            Data structure describing the project.
+        path : str or PathLike
+            Destination file where the model will be stored.
+        """
+        import json
+
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(model, fh)
 
     def load(self, path):
-        """Load the model from disk."""
+        """Load the model from disk.
+
+        Parameters
+        ----------
+        path : str or PathLike
+            Source file previously created with :meth:`save`.
+
+        Returns
+        -------
+        dict
+            Reconstructed project model.
+        """
+        import json
+
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
 


### PR DESCRIPTION
## Summary
- Implement JSON serialization in `ProjectManager` for saving/loading projects
- Add roundtrip test for project manager save/load functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68953276491c83249044c4724916bf5f