### PR TITLE
Centralize diameter color mapping

### DIFF
--- a/vigapp/graphics/utilities.py
+++ b/vigapp/graphics/utilities.py
@@ -23,6 +23,7 @@ def _require_ezdxf() -> None:
         )
 
 from ..models.constants import DIAM_CM
+from ..utils import DIAM_COLOR
 
 # Clearance (cm) so bars do not overlap stirrups
 CLEARANCE = 0.2
@@ -111,8 +112,6 @@ def _color_index(color: str | int) -> int:
     return _COLOR_MAP.get(str(color).lower(), 7)
 
 
-_COLOR_ORDER = ["red", "blue", "yellow"]
-DIAM_COLOR = {key: _COLOR_ORDER[i % len(_COLOR_ORDER)] for i, key in enumerate(DIAM_CM.keys())}
 DIAM_COLOR_IDX = {k: _color_index(c) for k, c in DIAM_COLOR.items()}
 _COLOR_NAME_ES = {
     "red": "Rojo",

--- a/vigapp/models/utils.py
+++ b/vigapp/models/utils.py
@@ -5,10 +5,7 @@ from typing import Optional
 from matplotlib.figure import Figure
 from PyQt5.QtWidgets import QWidget
 
-
-def color_for_diameter(diam):
-    """Return a color associated with a rebar diameter."""
-    return "#000000"
+from ..utils import color_for_diameter
 
 
 def latex_image(latex: str, fontsize: int = 6) -> str:

--- a/vigapp/utils.py
+++ b/vigapp/utils.py
@@ -2,10 +2,38 @@
 
 from matplotlib.figure import Figure
 
+from .models.constants import DIAM_CM
 
-def color_for_diameter(diam):
-    """Return a color associated with a rebar diameter."""
-    return "#000000"
+
+# Order of colours to cycle through for each diameter key
+_COLOR_ORDER = ["red", "blue", "yellow"]
+
+# Mapping of diameter labels to colours. This mirrors the mapping used in
+# :mod:`vigapp.graphics.utilities` so both modules remain consistent.
+DIAM_COLOR = {
+    key: _COLOR_ORDER[i % len(_COLOR_ORDER)]
+    for i, key in enumerate(DIAM_CM.keys())
+}
+
+_DEFAULT_COLOR = "black"
+
+
+def color_for_diameter(diam: str) -> str:
+    """Return a colour associated with a rebar diameter key.
+
+    Parameters
+    ----------
+    diam:
+        The label used to identify the rebar diameter (e.g. ``"12mm"``).
+
+    Returns
+    -------
+    str
+        Colour name for the given diameter or a default value when the
+        diameter is unknown.
+    """
+
+    return DIAM_COLOR.get(diam, _DEFAULT_COLOR)
 
 
 def latex_image(latex: str, fontsize: int = 10) -> str:


### PR DESCRIPTION
## Summary
- define `DIAM_COLOR` map in utils to share bar colors across modules
- use shared map in `color_for_diameter` with a default color
- reuse centralized colors in graphics and model utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689532772e5c8324b9b0e96b4375ff15